### PR TITLE
Fixed clip area related methods (Gtk and Cairo)

### DIFF
--- a/Source/Libs/CairoSharp/Context.cs
+++ b/Source/Libs/CairoSharp/Context.cs
@@ -620,6 +620,14 @@ namespace Cairo {
 			NativeMethods.cairo_clip (handle);
 		}
 
+		public Rectangle ClipExtents()
+		{
+			CheckDisposed();
+			double x1, y1, x2, y2;
+			NativeMethods.cairo_clip_extents(handle, out x1, out y1, out x2, out y2);
+			return new Rectangle(x1, y1, x2 - x1, y2 - y1);
+		}
+
 		public void ClipPreserve ()
 		{
 			CheckDisposed ();

--- a/Source/Libs/GtkSharp/GtkSharp.metadata
+++ b/Source/Libs/GtkSharp/GtkSharp.metadata
@@ -847,6 +847,7 @@
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='Destroyed']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='Event']" name="name">ProcessEvent</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='GetAllocation']/parameters/parameter[@name='allocation']" name="pass_as">out</attr>
+  <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='GetClip']/parameters/parameter[@name='clip']" name="pass_as">out</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='GetChildRequisition']/*/*[@name='requisition']" name="pass_as">out</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='GetEvents']/return-type" name="type">GdkEventMask</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='GetMapped']" name="name">GetIsMapped</attr>


### PR DESCRIPTION
While playing around with this library I noticed that there is no way of accesing clip areas for both Gtk and Cairo (apart from Allocation in Gtk).