### PR TITLE
[FIX] PangoSharp metadata (osx)

### DIFF
--- a/Source/Libs/PangoSharp/PangoSharp.metadata
+++ b/Source/Libs/PangoSharp/PangoSharp.metadata
@@ -101,6 +101,7 @@
   <attr path="/api/namespace/struct[@cname='PangoScriptIter']" name="hidden">1</attr>
   <attr path="/api/namespace/struct[@cname='PangoWin32FontCache']" name="hidden">1</attr>
   <attr path="/api/namespace/*[@cname='PangoWin32Family']" name="parent">PangoFontFamily</attr>
+  <attr path="/api/namespace/*[@cname='PangoCoreTextFamily']" name="parent">PangoFontFamily</attr>
   <move-node path="/api/namespace/class[@name='Version']/method[@cname='pango_version_check']">/api/namespace/class[@name='Global']</move-node>
   <move-node path="/api/namespace/class[@name='Version']/method[@cname='pango_version_string']">/api/namespace/class[@name='Global']</move-node>
 </metadata>


### PR DESCRIPTION
native name is PangoCoreTextFamily in Osx