### PR TITLE
Free all internal signals, else the garbage collector is not able to free the object.

### DIFF
--- a/Source/Libs/GLibSharp/Object.cs
+++ b/Source/Libs/GLibSharp/Object.cs
@@ -73,6 +73,16 @@ namespace GLib {
 				tref.Dispose ();
 			else
 				tref.QueueUnref ();
+
+			// Free all internal signals, else the garbage collector is not
+			// able to free the object.
+			if (signals != null)
+			{
+				foreach (var sig in signals.Keys)
+					signals[sig].Free ();
+			}
+
+			signals = null;
 		}
 
 		public static bool WarnOnFinalize { get; set; }


### PR DESCRIPTION
The garbage collector is not able to free the object if any signals are still present.

This will clean all the internal signals. Manually created signals should be unhooked by the developer.