### PR TITLE
Improve library loading code

### DIFF
--- a/Source/Libs/AtkSharp/AtkSharp-api.xml
+++ b/Source/Libs/AtkSharp/AtkSharp-api.xml
@@ -6,7 +6,7 @@
         Please DO NOT MODIFY THIS FILE, modify .metadata files instead.
 
 -->
-  <namespace name="Atk" library="libatk-1.0-0.dll">
+  <namespace name="Atk" library="Library.Atk">
     <enum name="CoordType" cname="AtkCoordType" gtype="atk_coord_type_get_type" type="enum">
       <member cname="ATK_XY_SCREEN" name="Screen" />
       <member cname="ATK_XY_WINDOW" name="Window" />

--- a/Source/Libs/GLibSharp/GLibSharp-api.xml
+++ b/Source/Libs/GLibSharp/GLibSharp-api.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <api>
-  <namespace name="GLib" library="libglib-2.0-0.dll">
+  <namespace name="GLib" library="Library.GLib">
     <enum name="ConnectFlags" cname="GConnectFlags" type="flags" />
     <enum name="IOCondition" cname="GIOCondition" type="enum" />
     <enum name="SeekType" cname="GSeekType" type="enum" />

--- a/Source/Libs/GdkSharp/GdkSharp-api.xml
+++ b/Source/Libs/GdkSharp/GdkSharp-api.xml
@@ -6,7 +6,7 @@
         Please DO NOT MODIFY THIS FILE, modify .metadata files instead.
 
 -->
-  <namespace name="Gdk" library="libgdk-3-0.dll">
+  <namespace name="Gdk" library="Library.Gdk">
     <enum name="AnchorHints" cname="GdkAnchorHints" gtype="gdk_anchor_hints_get_type" type="flags">
       <member cname="GDK_ANCHOR_FLIP_X" name="FlipX" value="1 &lt;&lt; 0" />
       <member cname="GDK_ANCHOR_FLIP_Y" name="FlipY" value="1 &lt;&lt; 1" />
@@ -5301,7 +5301,7 @@
       </method>
     </class>
   </namespace>
-  <namespace name="Gdk" library="libgdk_pixbuf-2.0-0.dll">
+  <namespace name="Gdk" library="Library.GdkPixbuf">
     <enum name="Colorspace" cname="GdkColorspace" gtype="gdk_colorspace_get_type" type="enum">
       <member cname="GDK_COLORSPACE_RGB" name="Rgb" />
     </enum>

--- a/Source/Libs/GioSharp/GioSharp-api.xml
+++ b/Source/Libs/GioSharp/GioSharp-api.xml
@@ -6,7 +6,7 @@
         Please DO NOT MODIFY THIS FILE, modify .metadata files instead.
 
 -->
-  <namespace name="G" library="libgio-2.0-0.dll">
+  <namespace name="G" library="Library.Gio">
     <enum name="AppInfoCreateFlags" cname="GAppInfoCreateFlags" gtype="g_app_info_create_flags_get_type" type="flags">
       <member cname="G_APP_INFO_CREATE_NONE" name="None" />
       <member cname="G_APP_INFO_CREATE_NEEDS_TERMINAL" name="NeedsTerminal" value="1 &lt;&lt; 0" />

--- a/Source/Libs/GtkSharp/Application.cs
+++ b/Source/Libs/GtkSharp/Application.cs
@@ -31,35 +31,12 @@ namespace Gtk {
 		const int WS_EX_TOOLWINDOW = 0x00000080;
 		const int WS_OVERLAPPEDWINDOW = 0x00CF0000;
 
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-		delegate IntPtr d_Win32CreateWindow(int dwExStyle, string lpClassName, string lpWindowName,int dwStyle, int x, int y, int nWidth, int nHeight, IntPtr hWndParent, IntPtr hMenu, IntPtr hInstance, IntPtr lParam);
-        static d_Win32CreateWindow Win32CreateWindow;
-
-        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
-		delegate bool d_Win32DestroyWindow(IntPtr window);
-        static d_Win32DestroyWindow Win32DestroyWindow;
-
         static Application ()
 		{
 			if (!GLib.Thread.Supported)
 				GLib.Thread.Init ();
-
-			switch (Environment.OSVersion.Platform) {
-			case PlatformID.Win32NT:
-			case PlatformID.Win32S:
-			case PlatformID.Win32Windows:
-			case PlatformID.WinCE:
-				Win32CreateWindow = FuncLoader.LoadFunction<d_Win32CreateWindow>(FuncLoader.GetProcAddress(GLibrary.Load("user32.dll"), "CreateWindowExW"));
-				Win32DestroyWindow = FuncLoader.LoadFunction<d_Win32DestroyWindow>(FuncLoader.GetProcAddress(GLibrary.Load("user32.dll"), "DestroyWindow"));
-
-				// No idea why we need to create that window, but it enables visual styles on the Windows platform
-				IntPtr window = Win32CreateWindow (WS_EX_TOOLWINDOW, "static", "gtk-sharp visual styles window", WS_OVERLAPPEDWINDOW, 0, 0, 0, 0, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero, IntPtr.Zero);
-				Win32DestroyWindow (window);
-				break;
-			default:
-				break;
-			}
 		}
+		
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		delegate void d_gtk_init(ref int argc, ref IntPtr argv);
 		static d_gtk_init gtk_init = FuncLoader.LoadFunction<d_gtk_init>(FuncLoader.GetProcAddress(GLibrary.Load(Library.Gtk), "gtk_init"));

--- a/Source/Libs/GtkSharp/GtkSharp-api.xml
+++ b/Source/Libs/GtkSharp/GtkSharp-api.xml
@@ -6,7 +6,7 @@
         Please DO NOT MODIFY THIS FILE, modify .metadata files instead.
 
 -->
-  <namespace name="Gtk" library="libgtk-3-0.dll">
+  <namespace name="Gtk" library="Library.Gtk">
     <enum name="AccelFlags" cname="GtkAccelFlags" gtype="gtk_accel_flags_get_type" type="flags">
       <member cname="GTK_ACCEL_VISIBLE" name="Visible" value="1 &lt;&lt; 0" />
       <member cname="GTK_ACCEL_LOCKED" name="Locked" value="1 &lt;&lt; 1" />

--- a/Source/Libs/PangoSharp/PangoSharp-api.xml
+++ b/Source/Libs/PangoSharp/PangoSharp-api.xml
@@ -6,7 +6,7 @@
         Please DO NOT MODIFY THIS FILE, modify .metadata files instead.
 
 -->
-  <namespace name="Pango" library="libpango-1.0-0.dll">
+  <namespace name="Pango" library="Library.Pango">
     <enum name="Alignment" cname="PangoAlignment" gtype="pango_alignment_get_type" type="enum">
       <member cname="PANGO_ALIGN_LEFT" name="Left" />
       <member cname="PANGO_ALIGN_CENTER" name="Center" />

--- a/Source/Libs/PangoSharp/PangoSharp.metadata
+++ b/Source/Libs/PangoSharp/PangoSharp.metadata
@@ -36,7 +36,7 @@
   <attr path="/api/namespace/class/method[@cname='pango_version_string']" name="name">VersionString</attr>
   <attr path="/api/namespace/class[@cname='PangoAttr_']" name="hidden">1</attr>
   <attr path="/api/namespace/class[@cname='PangoCairo_']" name="name">CairoHelper</attr>
-  <attr path="/api/namespace/class[@cname='PangoCairo_']/method" name="library">libpangocairo-1.0-0.dll</attr>
+  <attr path="/api/namespace/class[@cname='PangoCairo_']/method" name="library">Library.PangoCairo</attr>
   <attr path="/api/namespace/class[@cname='PangoCairo_']/method[@name='ContextGetFontOptions']" name="hidden">1</attr>
   <attr path="/api/namespace/class[@cname='PangoCairo_']/method[@name='ContextSetFontOptions']" name="hidden">1</attr>
   <attr path="/api/namespace/class[@cname='PangoGlobal']/method[@name='ExtentsToPixels']/*/*[@type='PangoRectangle*']" name="pass_as">ref</attr>

--- a/Source/Tools/GapiCodegen/Ctor.cs
+++ b/Source/Tools/GapiCodegen/Ctor.cs
@@ -67,7 +67,7 @@ namespace GtkSharp.Generation {
 		{
             sw.WriteLine("\t\t[UnmanagedFunctionPointer (CallingConvention.Cdecl)]");
             sw.WriteLine("\t\tdelegate IntPtr d_{0}({1});", CName, Parameters.ImportSignature);
-            sw.WriteLine("\t\tstatic d_{0} {0} = FuncLoader.LoadFunction<d_{0}>(FuncLoader.GetProcAddress(GLibrary.Load(\"{1}\"), \"{0}\"));", CName, LibraryName);
+            sw.WriteLine("\t\tstatic d_{0} {0} = FuncLoader.LoadFunction<d_{0}>(FuncLoader.GetProcAddress(GLibrary.Load({1}), \"{0}\"));", CName, LibraryName);
             sw.WriteLine();
 		}
 

--- a/Source/Tools/GapiCodegen/EnumGen.cs
+++ b/Source/Tools/GapiCodegen/EnumGen.cs
@@ -121,7 +121,7 @@ namespace GtkSharp.Generation {
                 var funcname = Elem.GetAttribute("gtype");
                 sw.WriteLine ("\t\t[UnmanagedFunctionPointer (CallingConvention.Cdecl)]");
                 sw.WriteLine ("\t\tdelegate IntPtr d_" + funcname + "();");
-				sw.WriteLine ("\t\tstatic d_" + funcname + " " + funcname + " = FuncLoader.LoadFunction<d_" + funcname + ">(FuncLoader.GetProcAddress(GLibrary.Load(\"" + LibraryName + "\"), \"" + funcname + "\"));");
+				sw.WriteLine ("\t\tstatic d_" + funcname + " " + funcname + " = FuncLoader.LoadFunction<d_" + funcname + ">(FuncLoader.GetProcAddress(GLibrary.Load(" + LibraryName + "), \"" + funcname + "\"));");
 				sw.WriteLine ();
 				sw.WriteLine ("\t\tpublic static GLib.GType GType {");
 				sw.WriteLine ("\t\t\tget {");

--- a/Source/Tools/GapiCodegen/Method.cs
+++ b/Source/Tools/GapiCodegen/Method.cs
@@ -198,7 +198,7 @@ namespace GtkSharp.Generation {
 				sw.WriteLine("\t\tdelegate " + retval.CSType + " d_" + CName + "(" + import_sig + ");");
 			else
                 sw.WriteLine("\t\tdelegate " + retval.MarshalType + " d_" + CName + "(" + import_sig + ");");
-			sw.WriteLine("\t\tstatic d_" + CName + " " + CName + " = FuncLoader.LoadFunction<d_" + CName + ">(FuncLoader.GetProcAddress(GLibrary.Load(\"" + LibraryName + "\"), \"" + CName + "\"));");
+			sw.WriteLine("\t\tstatic d_" + CName + " " + CName + " = FuncLoader.LoadFunction<d_" + CName + ">(FuncLoader.GetProcAddress(GLibrary.Load(" + LibraryName + "), \"" + CName + "\"));");
 			sw.WriteLine();
 		}
 

--- a/Source/Tools/GapiCodegen/OpaqueGen.cs
+++ b/Source/Tools/GapiCodegen/OpaqueGen.cs
@@ -186,7 +186,7 @@ namespace GtkSharp.Generation {
 #endif
 			if (set_gvalue != null) {
 				sw.WriteLine("\t\tdelegate IntPtr d_{0}(ref GLib.Value val, IntPtr obj);", set_gvalue.CName);
-                sw.WriteLine("\t\tstatic d_{0} {0} = FuncLoader.LoadFunction<d_{0}>(FuncLoader.GetProcAddress(GLibrary.Load(\"{1}\"), \"{0}\"));", set_gvalue.CName, LibraryName);
+                sw.WriteLine("\t\tstatic d_{0} {0} = FuncLoader.LoadFunction<d_{0}>(FuncLoader.GetProcAddress(GLibrary.Load({1}), \"{0}\"));", set_gvalue.CName, LibraryName);
 				sw.WriteLine ();
 				sw.WriteLine ("\t\tpublic void SetGValue (ref GLib.Value val)");
 				sw.WriteLine ("\t\t{");


### PR DESCRIPTION
Stuff done:
- No longer allows a function that loads string, instead uses an enum, skips a find
- Added secondary library names for Windows Gtk 3 library
- Improved code for trying to load Gtk library to try all the filenames and print out the tried filenames in the DllNotFoundException