### PR TITLE
Combobox.entry fix invalid cast exception

### DIFF
--- a/Source/Libs/GtkSharp/ComboBox.cs
+++ b/Source/Libs/GtkSharp/ComboBox.cs
@@ -52,7 +52,7 @@ namespace Gtk {
 
 		public Gtk.Entry Entry {
 			get {
-				return (Gtk.Entry)Child;
+				return Child as Gtk.Entry;
 			}
 		}
 

--- a/Source/Libs/GtkSharp/ComboBoxText.cs
+++ b/Source/Libs/GtkSharp/ComboBoxText.cs
@@ -39,10 +39,5 @@ namespace Gtk {
 			}
 		}
 
-		public Gtk.Entry Entry {
-			get {
-				return (Gtk.Entry)Child;
-			}
-		}
 	}
 }


### PR DESCRIPTION
If a Gtk.ComboBox is created without an Entry, referencing  ComboBox.Entry will generate an InvalidCastType exception since Child in this case is a CellRenderer rather than an Entry.

I've changed it to use 'as' so it will return null if there is no Entry.

I don't think it's worth checking HasEntry property?

Same issue occurs in Gtk.ComboBoxText.Entry.
In this case, ComboBoxText.Entry is actually hiding ComboBox.Entry, so since they are currently identical, I've just removed ComboBoxText.Entry so it inherits it from ComboBox instead.
