### PR TITLE
Change GtkWidget.ListActionPrefixes() to return string[] 

### DIFF
--- a/Source/Libs/GtkSharp/GtkSharp.metadata
+++ b/Source/Libs/GtkSharp/GtkSharp.metadata
@@ -863,6 +863,7 @@
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='Intersect']/*/*[@name='intersection']" name="pass_as">out</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='IsFocus']" name="name">GetIsFocus</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='ListAccelClosures']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='ListActionPrefixes']/return-type" name="null_term_array">1</attr>  
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='ListMnemonicLabels']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='Path']/*/*[@type='gchar**']" name="pass_as">out</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='SetEvents']/*/*[@type='gint']" name="type">GdkEventMask</attr>


### PR DESCRIPTION
GtkWidget.ListActionPrefixes() is currently returning a string, but it's mangled because the underlying gtk_widget_list_action_prefixes is actually returning a null-terminated array of strings...
[const gchar ** gtk_widget_list_action_prefixes (GtkWidget *widget);](https://developer.gnome.org/gtk3/stable/GtkWidget.html#gtk-widget-list-action-prefixes)

So added a line to metadata file including null_term_array = 1
