### PR TITLE
Remove GdkSeatDefault & GdkSeatDefaultClass

### DIFF
--- a/Source/Libs/GdkSharp/GdkSharp-api.xml
+++ b/Source/Libs/GdkSharp/GdkSharp-api.xml
@@ -4306,8 +4306,6 @@
       </method>
     </struct>
     <alias name="Rectangle" cname="GdkRectangle" type="cairo_rectangle_int_t" />
-    <struct name="SeatDefault" cname="GdkSeatDefault" opaque="true" />
-    <struct name="SeatDefaultClass" cname="GdkSeatDefaultClass" opaque="true" />
     <struct name="ThreadsDispatch" cname="GdkThreadsDispatch" opaque="true" />
     <struct name="TimeCoord" cname="GdkTimeCoord">
       <field name="Time" cname="time" type="guint32" />


### PR DESCRIPTION
I believe the generated Gdk.SeatDefault* classes are not required, and is preventing the return from gdk_display_get_default_seat() from being correctly instantiated as a Gdk.Seat.

Please see #131 (GDK Seat API not working) for more information.

NB: I can't see any other dependency or requirement for Gdk.SeatDefault, but I am still learning about the GtkSharp auto generated code.