### PR TITLE
Change Gtk.SelectionData Uris & SetUris to use string[]

### DIFF
--- a/Source/Libs/GtkSharp/GtkSharp-api.xml
+++ b/Source/Libs/GtkSharp/GtkSharp-api.xml
@@ -31967,7 +31967,7 @@
         <return-type type="GType" />
       </method>
       <method name="GetUris" cname="gtk_selection_data_get_uris">
-        <return-type type="gchar**" />
+        <return-type type="gchar**" null_term_array="1" />
       </method>
       <method name="Set" cname="gtk_selection_data_set">
         <return-type type="void" />
@@ -31994,7 +31994,7 @@
       <method name="SetUris" cname="gtk_selection_data_set_uris">
         <return-type type="gboolean" />
         <parameters>
-          <parameter type="gchar**" name="uris" />
+          <parameter type="gchar**" name="uris" null_term_array="1" />
         </parameters>
       </method>
       <method name="TargetsIncludeImage" cname="gtk_selection_data_targets_include_image">


### PR DESCRIPTION
 Gtk.SelectionData.Uris is currently returning a string, but the underlying gtk_selection_data_get_uris call is actually returning a null-terminated array of strings...
`gchar ** gtk_selection_data_get_uris (const GtkSelectionData *selection_data);`
Similarly for Gtk.SelectionData.SetUris()...
`gboolean gtk_selection_data_set_uris (GtkSelectionData *selection_data, gchar **uris);`

So added 2 x `null_term_array = "1"` to metadata file.

See #105
