### PR TITLE
Fix for memory leak(Issue 135)

### DIFF
--- a/Source/Tools/GapiCodegen/OpaqueGen.cs
+++ b/Source/Tools/GapiCodegen/OpaqueGen.cs
@@ -146,6 +146,7 @@ namespace GtkSharp.Generation {
 			if (finalizer_needed) {
 				sw.WriteLine ("\t\tclass FinalizerInfo {");
 				sw.WriteLine ("\t\t\tIntPtr handle;");
+				sw.WriteLine ("\t\t\tuint timeoutHandlerId;");
 				sw.WriteLine ();
 				sw.WriteLine ("\t\t\tpublic FinalizerInfo (IntPtr handle)");
 				sw.WriteLine ("\t\t\t{");
@@ -158,6 +159,7 @@ namespace GtkSharp.Generation {
 					sw.WriteLine ("\t\t\t\t{0} (handle);", dispose.CName);
 				else if (unref != null)
 					sw.WriteLine ("\t\t\t\t{0} (handle);", unref.CName);
+				sw.WriteLine ("\t\t\t\tGLib.Timeout.Remove(timeoutHandlerId);");
 				sw.WriteLine ("\t\t\t\treturn false;");
 				sw.WriteLine ("\t\t\t}");
 				sw.WriteLine ("\t\t}");
@@ -167,7 +169,7 @@ namespace GtkSharp.Generation {
 				sw.WriteLine ("\t\t\tif (!Owned)");
 				sw.WriteLine ("\t\t\t\treturn;");
 				sw.WriteLine ("\t\t\tFinalizerInfo info = new FinalizerInfo (Handle);");
-				sw.WriteLine ("\t\t\tGLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));");
+				sw.WriteLine ("\t\t\tinfo.timeoutHandlerId = GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));");
 				sw.WriteLine ("\t\t}");
 				sw.WriteLine ();
 			}

--- a/Source/Tools/GapiCodegen/OpaqueGen.cs
+++ b/Source/Tools/GapiCodegen/OpaqueGen.cs
@@ -146,7 +146,7 @@ namespace GtkSharp.Generation {
 			if (finalizer_needed) {
 				sw.WriteLine ("\t\tclass FinalizerInfo {");
 				sw.WriteLine ("\t\t\tIntPtr handle;");
-				sw.WriteLine ("\t\t\tuint timeoutHandlerId;");
+				sw.WriteLine ("\t\t\tpublic uint timeoutHandlerId;");
 				sw.WriteLine ();
 				sw.WriteLine ("\t\t\tpublic FinalizerInfo (IntPtr handle)");
 				sw.WriteLine ("\t\t\t{");


### PR DESCRIPTION
Adding code to remove the timeouthandler from source_handlers in Source.cs

The FinalizerInfo class generated by OpaqueGen.cs doesnt remove the TimeoutHandler Ids added to the static dictionary private static IDictionary<uint, SourceProxy> source_handlers in Source.cs .
This would lead to the memory growing continuously with each source_handler added. Could see it filling up GBs in matter of few hours when used with Gstreamer pipelines and objects created with Gstreamer-Sharp bindings for C#

