### PR TITLE
Change Gtk.Application action/accel related calls to use string[]

### DIFF
--- a/Source/Libs/GtkSharp/GtkSharp-api.xml
+++ b/Source/Libs/GtkSharp/GtkSharp-api.xml
@@ -5408,7 +5408,7 @@
         </parameters>
       </method>
       <method name="GetAccelsForAction" cname="gtk_application_get_accels_for_action">
-        <return-type type="gchar**" />
+        <return-type type="const-gchar**" />
         <parameters>
           <parameter type="const-gchar*" name="detailed_action_name" />
         </parameters>
@@ -5489,7 +5489,7 @@
         <return-type type="void" />
         <parameters>
           <parameter type="const-gchar*" name="detailed_action_name" />
-          <parameter type="const-gchar*" name="accels" />
+          <parameter type="const-gchar**" name="accels" />
         </parameters>
       </method>
       <method name="SetAppMenu" cname="gtk_application_set_app_menu">

--- a/Source/Libs/GtkSharp/GtkSharp.metadata
+++ b/Source/Libs/GtkSharp/GtkSharp.metadata
@@ -251,6 +251,9 @@
   <attr path="/api/namespace/object[@cname='GtkAdjustment']/method[@name='Changed']" name="name">Change</attr>
   <attr path="/api/namespace/object[@cname='GtkAdjustment']/method[@name='ValueChanged']" name="name">ChangeValue</attr>
   <attr path="/api/namespace/object[@cname='GtkApplication']/method[@name='GetWindows']/return-type" name="element_type">GtkWindow*</attr>
+  <attr path="/api/namespace/object[@cname='GtkApplication']/method[@name='SetAccelsForAction']/*/*[@name='accels']" name="null_term_array">1</attr>
+  <attr path="/api/namespace/object[@cname='GtkApplication']/method[@name='GetAccelsForAction']/return-type" name="null_term_array">1</attr>
+  <attr path="/api/namespace/object[@cname='GtkApplication']/method[@name='GetActionsForAccel']/return-type" name="null_term_array">1</attr>
   <attr path="/api/namespace/object[@cname='GtkArrow']/method[@name='Set']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkBin']/method[@name='GetChild']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkBuilder']/constructor[@cname='gtk_builder_new_from_file']" name="hidden">1</attr>


### PR DESCRIPTION
Update GtkSharp.metadata so following functions accept/return string[] instead of string:
GtkApplication.GetAccelsForAction
GtkApplication.SetAccelsForAction
GtkApplication.GetActionsForAccel

Should fix:
#142 Probably invalid signature for Gtk.Application.SetAccelsForAction
