### PR TITLE
Handle NULL in GLib.Value -> GLib.Variant cast operator

### DIFF
--- a/Source/Libs/GLibSharp/Value.cs
+++ b/Source/Libs/GLibSharp/Value.cs
@@ -275,9 +275,10 @@ namespace GLib {
 			return GLib.Opaque.GetOpaque (g_value_get_boxed (ref val), (Type) new GType (val.type), false);
 		}
 
-		public static explicit operator GLib.Variant (Value Val)
+		public static explicit operator GLib.Variant (Value val)
 		{
-			return new Variant (g_value_get_variant (ref Val));
+			IntPtr native_variant = g_value_get_variant (ref val);
+			return native_variant == IntPtr.Zero ? null : new Variant (native_variant);
 		}
 
 		public static explicit operator GLib.VariantType (Value val)


### PR DESCRIPTION
If a GLib.Value happens to contain a `NULL` GLib.Variant and at some point is "unwrapped" to a managed `object` (e.g. in a [SignalClosure](https://github.com/GtkSharp/GtkSharp/blob/40773f3c881045e263abed1e13e05467c025a6fa/Source/Libs/GLibSharp/SignalClosure.cs#L164)), native GLib complains:

```
GLib-CRITICAL **: 21:17:12.546: g_variant_ref_sink: assertion 'value != NULL' failed
```

This happens because the GLib.Value -> GLib.Variant cast operator calls the `GLib.Variant (IntPtr)` constructor even if the pointer is a NULL pointer.

The warning is particularly annoying since this happens whenever a parameterless GLib.SimpleAction gets activated 😉