### PR TITLE
Gtk.Container & Gtk.CellRenderer: nullcheck in glue-methods

### DIFF
--- a/Source/Libs/GtkSharp/CellRenderer.GetSize.cs
+++ b/Source/Libs/GtkSharp/CellRenderer.GetSize.cs
@@ -127,6 +127,8 @@ namespace Gtk
 			}
 
 			var obj = TryGetObject (cell);
+			if (obj == default)
+				return;
 			var parent = obj.NativeType;
 			while ((parent = parent.GetBaseType ()) != GLib.GType.None) {
 				

--- a/Source/Libs/GtkSharp/Container.Forall.cs
+++ b/Source/Libs/GtkSharp/Container.Forall.cs
@@ -137,6 +137,9 @@ namespace Gtk
 				return;
 
 			var obj = TryGetObject(container);
+			if (obj == default)
+				return;
+			
 			var parent = obj.NativeType;
 			while ((parent = parent.GetBaseType()) != GLib.GType.None) {
 				if (parent.ToString().StartsWith("__gtksharp_")) {


### PR DESCRIPTION
Gtk.Container.gtksharp_container_base_forall & CellRenderer.gtksharp.cellrenderer_base_get_size: check if obj is null

if Widget.Dispose is called, TryGetObject can fail (=gives back null)
therefore check for null