### PR TITLE
Implement Cairo.Context.PathExtents()

### DIFF
--- a/Source/Libs/CairoSharp/Context.cs
+++ b/Source/Libs/CairoSharp/Context.cs
@@ -545,6 +545,14 @@ namespace Cairo {
 			NativeMethods.cairo_append_path (handle, path.Handle);
 		}
 
+		public Rectangle PathExtents ()
+		{
+			CheckDisposed ();
+			double x1, y1, x2, y2;
+			NativeMethods.cairo_path_extents (handle, out x1, out y1, out x2, out y2);
+			return new Rectangle (x1, y1, x2 - x1, y2 - y1);
+		}
+
 #endregion
 
 #region Painting Methods


### PR DESCRIPTION
This exposes the cairo_path_extents() method (https://www.cairographics.org/manual/cairo-Paths.html#cairo-path-extents), and is closely related to the existing StrokeExtents() method.