### PR TITLE
Add Gdk.Pixbuf constructors for a source Gdk.Window or Cairo.Surface.

### DIFF
--- a/Source/Libs/GdkSharp/GdkSharp-api.xml
+++ b/Source/Libs/GdkSharp/GdkSharp-api.xml
@@ -5033,28 +5033,6 @@
         </parameters>
       </method>
     </class>
-    <class name="Pixbuf" cname="GdkPixbuf_">
-      <method name="GetFromSurface" cname="gdk_pixbuf_get_from_surface" shared="true">
-        <return-type type="GdkPixbuf*" />
-        <parameters>
-          <parameter type="cairo_surface_t*" name="surface" />
-          <parameter type="gint" name="src_x" />
-          <parameter type="gint" name="src_y" />
-          <parameter type="gint" name="width" />
-          <parameter type="gint" name="height" />
-        </parameters>
-      </method>
-      <method name="GetFromWindow" cname="gdk_pixbuf_get_from_window" shared="true">
-        <return-type type="GdkPixbuf*" />
-        <parameters>
-          <parameter type="GdkWindow*" name="window" />
-          <parameter type="gint" name="src_x" />
-          <parameter type="gint" name="src_y" />
-          <parameter type="gint" name="width" />
-          <parameter type="gint" name="height" />
-        </parameters>
-      </method>
-    </class>
     <class name="Pointer" cname="GdkPointer_">
       <method name="Grab" cname="gdk_pointer_grab" deprecated="1" shared="true">
         <return-type type="GdkGrabStatus" />
@@ -5707,6 +5685,24 @@
           <parameter type="int" name="src_y" />
           <parameter type="int" name="width" />
           <parameter type="int" name="height" />
+        </parameters>
+      </constructor>
+      <constructor cname="gdk_pixbuf_get_from_surface">
+        <parameters>
+          <parameter type="cairo_surface_t*" name="surface" />
+          <parameter type="gint" name="src_x" />
+          <parameter type="gint" name="src_y" />
+          <parameter type="gint" name="width" />
+          <parameter type="gint" name="height" />
+        </parameters>
+      </constructor>
+      <constructor cname="gdk_pixbuf_get_from_window">
+        <parameters>
+          <parameter type="GdkWindow*" name="window" />
+          <parameter type="gint" name="src_x" />
+          <parameter type="gint" name="src_y" />
+          <parameter type="gint" name="width" />
+          <parameter type="gint" name="height" />
         </parameters>
       </constructor>
       <method name="ReadPixelBytes" cname="gdk_pixbuf_read_pixel_bytes">

--- a/Source/Libs/GdkSharp/GdkSharp.metadata
+++ b/Source/Libs/GdkSharp/GdkSharp.metadata
@@ -28,7 +28,6 @@
   <attr path="/api/namespace/class[@cname='GdkNotify_']" name="hidden">1</attr>
   <attr path="/api/namespace/class/method[@cname='gdk_notify_startup_complete']" name="name">NotifyStartupComplete</attr>
   <attr path="/api/namespace/class[@cname='GdkPango_']" name="name">PangoHelper</attr>
-  <attr path="/api/namespace/class[@cname='GdkPixbuf_']" name="hidden">1</attr>
   <attr path="/api/namespace/class[@cname='GdkProperty_']/method[@name='Get']" name="hidden">1</attr>
   <attr path="/api/namespace/class[@cname='GdkProperty_']/method[@name='Change']/*/*[@name='data']" name="array">1</attr>
   <attr path="/api/namespace/class[@cname='GdkQuery_']" name="hidden">1</attr>


### PR DESCRIPTION
This exposes `gdk_pixbuf_get_from_window` and `gdk_pixbuf_get_from_surface` (https://developer.gnome.org/gdk3/stable/gdk3-Pixbufs.html#gdk-pixbuf-get-from-window) via Gdk.Pixbuf constructors. Previously they were in a hidden `GdkPixbuf_` class and unavailable.

Fixes: #174