### PR TITLE
Fix runtime errors when calling the Gdk.Pixbuf constructors that take Gdk.Window or Cairo.Surface

### DIFF
--- a/Source/Libs/GdkSharp/GdkSharp-api.xml
+++ b/Source/Libs/GdkSharp/GdkSharp-api.xml
@@ -5687,7 +5687,7 @@
           <parameter type="int" name="height" />
         </parameters>
       </constructor>
-      <constructor cname="gdk_pixbuf_get_from_surface">
+      <constructor cname="gdk_pixbuf_get_from_surface" library="Library.Gdk">
         <parameters>
           <parameter type="cairo_surface_t*" name="surface" />
           <parameter type="gint" name="src_x" />
@@ -5696,7 +5696,7 @@
           <parameter type="gint" name="height" />
         </parameters>
       </constructor>
-      <constructor cname="gdk_pixbuf_get_from_window">
+      <constructor cname="gdk_pixbuf_get_from_window" library="Library.Gdk">
         <parameters>
           <parameter type="GdkWindow*" name="window" />
           <parameter type="gint" name="src_x" />


### PR DESCRIPTION
This was an issue with the changes in #176 - apologies for not testing this thoroughly enough!

`gdk_pixbuf_get_from_surface()` is in `libgdk`, not `libgdk_pixbuf` - this needs to be explicitly specified since 3a67da38 relocated these methods into `Gdk.Pixbuf`, which is underneath an element that specified `library="Library.GdkPixbuf"`

This fixes errors at run time when calling this method (similar for `gdk_pixbuf_get_from_window()`)