### PR TITLE
Fix crash when accessing Pango.FontFamily.Faces

### DIFF
--- a/Source/Libs/PangoSharp/PangoSharp.metadata
+++ b/Source/Libs/PangoSharp/PangoSharp.metadata
@@ -101,7 +101,9 @@
   <attr path="/api/namespace/struct[@cname='PangoScriptIter']" name="hidden">1</attr>
   <attr path="/api/namespace/struct[@cname='PangoWin32FontCache']" name="hidden">1</attr>
   <attr path="/api/namespace/*[@cname='PangoWin32Family']" name="parent">PangoFontFamily</attr>
+  <attr path="/api/namespace/*[@cname='PangoWin32Face']" name="parent">PangoFontFace</attr>
   <attr path="/api/namespace/*[@cname='PangoCoreTextFamily']" name="parent">PangoFontFamily</attr>
+  <attr path="/api/namespace/*[@cname='PangoCoreTextFace']" name="parent">PangoFontFace</attr>
   <move-node path="/api/namespace/class[@name='Version']/method[@cname='pango_version_check']">/api/namespace/class[@name='Global']</move-node>
   <move-node path="/api/namespace/class[@name='Version']/method[@cname='pango_version_string']">/api/namespace/class[@name='Global']</move-node>
 </metadata>


### PR DESCRIPTION
I tested this on OSX by adding the following code to `DrawingAreaSection::draw_text` in the samples:
```
var family = layout.Context.Families[0];
var faces = family.Faces;
```

This is similar to the fix for FontFamily in #35, and adds metadata for the parent class.
Without this, I found that the conversion to GObject failed in GLib.Object.GetObject and the pointer was deleted, corrupting memory for the next call.

Fixes: #159