### PR TITLE
Fixed Container.ChildGetProperty

### DIFF
--- a/Source/Libs/GtkSharp/Container.cs
+++ b/Source/Libs/GtkSharp/Container.cs
@@ -27,12 +27,12 @@ namespace Gtk
 
     public partial class Container : IEnumerable
     {
-		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-		delegate GParamSpec d_gtk_container_class_find_child_property(IntPtr cclass, string property_name);
-		static d_gtk_container_class_find_child_property gtk_container_class_find_child_property = FuncLoader.LoadFunction<d_gtk_container_class_find_child_property>(FuncLoader.GetProcAddress(GLibrary.Load(Library.Gtk), "gtk_container_class_find_child_property"));
-		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-		delegate void d_gtk_container_child_get_property(IntPtr container, IntPtr child, string property_name, ref GLib.Value value);
-		static d_gtk_container_child_get_property gtk_container_child_get_property = FuncLoader.LoadFunction<d_gtk_container_child_get_property>(FuncLoader.GetProcAddress(GLibrary.Load(Library.Gtk), "gtk_container_child_get_property"));
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        delegate IntPtr d_gtk_container_class_find_child_property(IntPtr cclass, string property_name);
+        static d_gtk_container_class_find_child_property gtk_container_class_find_child_property = FuncLoader.LoadFunction<d_gtk_container_class_find_child_property>(FuncLoader.GetProcAddress(GLibrary.Load(Library.Gtk), "gtk_container_class_find_child_property"));
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        delegate void d_gtk_container_child_get_property(IntPtr container, IntPtr child, string property_name, ref GLib.Value value);
+        static d_gtk_container_child_get_property gtk_container_child_get_property = FuncLoader.LoadFunction<d_gtk_container_child_get_property>(FuncLoader.GetProcAddress(GLibrary.Load(Library.Gtk), "gtk_container_child_get_property"));
 
         struct GTypeInstance
         {
@@ -59,7 +59,8 @@ namespace Gtk
         {
             var value = new GLib.Value();
             var cclass = ((GTypeInstance)Marshal.PtrToStructure(Handle, typeof(GTypeInstance))).GTypeClass;
-            var prop = gtk_container_class_find_child_property(cclass, property_name);
+            var propPtr = gtk_container_class_find_child_property(cclass, property_name);
+            var prop = (GParamSpec)Marshal.PtrToStructure(propPtr, typeof(GParamSpec));
 
             value.Init(prop.value_type);
             gtk_container_child_get_property(Handle, child.Handle, property_name, ref value);


### PR DESCRIPTION
Properly marshal `gtk_container_class_find_child_property` with return type of pointer instead of struct. Then marshal pointer to struct manually.

Fixes #193.