### PR TITLE
Set the correct parent class for Gdk.SeatDefault

### DIFF
--- a/Source/Libs/GdkSharp/GdkSharp.metadata
+++ b/Source/Libs/GdkSharp/GdkSharp.metadata
@@ -163,6 +163,7 @@
   <attr path="/api/namespace/struct[@cname='GdkPixdata']/method[@name='Deserialize']/*/*[@name='stream']" name="array">1</attr>
   <attr path="/api/namespace/struct[@cname='GdkPixdata']/method[@name='Serialize']" name="hidden">1</attr>
   <attr path="/api/namespace/struct[@cname='GdkPixdata']/method[@name='ToCsource']" name="hidden">1</attr>
+  <attr path="/api/namespace/struct[@cname='GdkSeatDefault']" name="parent">GdkSeat</attr>
   <attr path="/api/namespace/struct[@cname='GdkTimeCoord']/field[@cname='axes']" name="array_len">128</attr>
   <remove-node path="/api/namespace/object[@cname='GdkCursor']/method[@name='Ref']" />
   <remove-node path="/api/namespace/object[@cname='GdkCursor']/method[@name='Unref']" />

--- a/Source/Samples/Sections/Miscellaneous/SeatSection.cs
+++ b/Source/Samples/Sections/Miscellaneous/SeatSection.cs
@@ -1,0 +1,32 @@
+using System;
+using Gtk;
+
+namespace Samples
+{
+    [Section(ContentType=typeof(SeatDemo), Category = Category.Miscellaneous)]
+    class SeatSection : ListSection
+    {
+        public SeatSection()
+        {
+            AddItem("Press button to output mouse location:", new SeatDemo("Press me"));
+        }
+    }
+
+    class SeatDemo : Button
+    {
+        public SeatDemo(string text) : base(text)
+        {
+        }
+
+        protected override void OnPressed()
+        {
+            base.OnPressed();
+
+            var seat = Display.DefaultSeat;
+            ApplicationOutput.WriteLine($"Default seat: {seat}");
+
+            seat.Pointer.GetPosition(null, out int x, out int y);
+            ApplicationOutput.WriteLine($"Position: ({x}, {y})");
+        }
+    }
+}


### PR DESCRIPTION
This fixes issues with using the Gdk.Seat value returned by  `gdk_display_get_default_seat()`.

I mentioned this approach in the comments for https://github.com/GtkSharp/GtkSharp/pull/133#issuecomment-684115841, so that PR could be closed if this one is merged.

Fixes: #131