### PR TITLE
Cherry pick fixes from https://github.com/GlibSharp/GtkSharp/

### DIFF
--- a/Source/Libs/GLibSharp/Idle.cs
+++ b/Source/Libs/GLibSharp/Idle.cs
@@ -10,7 +10,7 @@
 // Copyright (c) 2009 Novell, Inc.
 //
 // This program is free software; you can redistribute it and/or
-// modify it under the terms of version 2 of the Lesser GNU General 
+// modify it under the terms of version 2 of the Lesser GNU General
 // Public License as published by the Free Software Foundation.
 //
 // This program is distributed in the hope that it will be useful,
@@ -64,14 +64,14 @@ namespace GLib {
 				return false;
 			}
 		}
-		
+
 		private Idle ()
 		{
 		}
-		
+
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-		delegate uint d_g_idle_add(IdleHandlerInternal d, IntPtr data);
-		static d_g_idle_add g_idle_add = FuncLoader.LoadFunction<d_g_idle_add>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GLib), "g_idle_add"));
+		delegate uint d_g_idle_add_full(int priority, IdleHandlerInternal d, IntPtr data, DestroyNotify notify);
+		static d_g_idle_add_full g_idle_add_full = FuncLoader.LoadFunction<d_g_idle_add_full>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GLib), "g_idle_add_full"));
 
 		public static uint Add (IdleHandler hndlr)
 		{
@@ -81,35 +81,14 @@ namespace GLib {
 				var gch = GCHandle.Alloc(p);
 				var userData = GCHandle.ToIntPtr(gch);
 				p.ID = g_idle_add_full (0, (IdleHandlerInternal) p.proxy_handler, userData, DestroyHelper.NotifyHandler);
-				Source.AddSourceHandler (p.ID, p);
 			}
 
 			return p.ID;
 		}
-		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-		delegate uint d_g_idle_add_full(int priority, IdleHandlerInternal d, IntPtr data, DestroyNotify notify);
-		static d_g_idle_add_full g_idle_add_full = FuncLoader.LoadFunction<d_g_idle_add_full>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GLib), "g_idle_add_full"));
 
-		public static uint Add (IdleHandler hndlr, Priority priority)
-		{
-			IdleProxy p = new IdleProxy (hndlr);
-			lock (p)
-			{
-				p.ID = g_idle_add_full ((int)priority, (IdleHandlerInternal)p.proxy_handler, IntPtr.Zero, null);
-				Source.AddSourceHandler (p.ID, p);
-			}
-
-			return p.ID;
-		}
-		
 		public static void Remove (uint id)
 		{
 			Source.Remove (id);
-		}
-
-		public static bool Remove (IdleHandler hndlr)
-		{
-			return Source.RemoveSourceHandler (hndlr);
 		}
 	}
 }

--- a/Source/Libs/GLibSharp/Idle.cs
+++ b/Source/Libs/GLibSharp/Idle.cs
@@ -78,7 +78,9 @@ namespace GLib {
 			IdleProxy p = new IdleProxy (hndlr);
 			lock (p)
 			{
-				p.ID = g_idle_add ((IdleHandlerInternal) p.proxy_handler, IntPtr.Zero);
+				var gch = GCHandle.Alloc(p);
+				var userData = GCHandle.ToIntPtr(gch);
+				p.ID = g_idle_add_full (0, (IdleHandlerInternal) p.proxy_handler, userData, DestroyHelper.NotifyHandler);
 				Source.AddSourceHandler (p.ID, p);
 			}
 

--- a/Source/Libs/GLibSharp/InitiallyUnowned.cs
+++ b/Source/Libs/GLibSharp/InitiallyUnowned.cs
@@ -5,7 +5,7 @@
 // Copyright (c) 2004-2005 Novell, Inc.
 //
 // This program is free software; you can redistribute it and/or
-// modify it under the terms of version 2 of the Lesser GNU General 
+// modify it under the terms of version 2 of the Lesser GNU General
 // Public License as published by the Free Software Foundation.
 //
 // This program is distributed in the hope that it will be useful,
@@ -38,26 +38,19 @@ namespace GLib {
 			}
 		}
 
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		delegate void d_g_object_ref_sink(IntPtr raw);
 		static d_g_object_ref_sink g_object_ref_sink = FuncLoader.LoadFunction<d_g_object_ref_sink>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GObject), "g_object_ref_sink"));
 
-		protected override IntPtr Raw {
-			get {
-				return base.Raw;
-			}
-			set {
-				if (value != IntPtr.Zero)
-					g_object_ref_sink (value);
-				base.Raw = value;
-			}
-		}
-
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		delegate bool d_g_object_is_floating(IntPtr raw);
 		static d_g_object_is_floating g_object_is_floating = FuncLoader.LoadFunction<d_g_object_is_floating>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GObject), "g_object_is_floating"));
 
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		delegate void d_g_object_force_floating(IntPtr raw);
 		static d_g_object_force_floating g_object_force_floating = FuncLoader.LoadFunction<d_g_object_force_floating>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GObject), "g_object_force_floating"));
 
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		delegate void d_g_object_unref(IntPtr raw);
 		static d_g_object_unref g_object_unref = FuncLoader.LoadFunction<d_g_object_unref>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GObject), "g_object_unref"));
 

--- a/Source/Libs/GLibSharp/InitiallyUnowned.cs
+++ b/Source/Libs/GLibSharp/InitiallyUnowned.cs
@@ -21,10 +21,55 @@
 namespace GLib {
 
 	using System;
+	using System.Runtime.InteropServices;
 
 	public class InitiallyUnowned : Object {
 
 		protected InitiallyUnowned (IntPtr raw) : base (raw) {}
+
+		public new static GLib.GType GType {
+			get {
+				return GType.Object;
+			}
+		}
+
+		delegate void d_g_object_ref_sink(IntPtr raw);
+		static d_g_object_ref_sink g_object_ref_sink = FuncLoader.LoadFunction<d_g_object_ref_sink>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GObject), "g_object_ref_sink"));
+
+		protected override IntPtr Raw {
+			get {
+				return base.Raw;
+			}
+			set {
+				if (value != IntPtr.Zero)
+					g_object_ref_sink (value);
+				base.Raw = value;
+			}
+		}
+
+		delegate bool d_g_object_is_floating(IntPtr raw);
+		static d_g_object_is_floating g_object_is_floating = FuncLoader.LoadFunction<d_g_object_is_floating>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GObject), "g_object_is_floating"));
+
+		delegate void d_g_object_force_floating(IntPtr raw);
+		static d_g_object_force_floating g_object_force_floating = FuncLoader.LoadFunction<d_g_object_force_floating>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GObject), "g_object_force_floating"));
+
+		delegate void d_g_object_unref(IntPtr raw);
+		static d_g_object_unref g_object_unref = FuncLoader.LoadFunction<d_g_object_unref>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GObject), "g_object_unref"));
+
+		public bool IsFloating {
+			get {
+				return g_object_is_floating (Handle);
+			}
+			set {
+			  	if (value == true) {
+					if (!IsFloating)
+						g_object_force_floating (Handle);
+				} else {
+					g_object_ref_sink (Handle);
+					g_object_unref (Handle);
+				}
+			}
+		}
 	}
 }
 

--- a/Source/Libs/GLibSharp/InitiallyUnowned.cs
+++ b/Source/Libs/GLibSharp/InitiallyUnowned.cs
@@ -27,9 +27,14 @@ namespace GLib {
 
 		protected InitiallyUnowned (IntPtr raw) : base (raw) {}
 
+		delegate IntPtr d_g_initially_unowned_get_type ();
+		static d_g_initially_unowned_get_type g_initially_unowned_get_type = FuncLoader.LoadFunction<d_g_initially_unowned_get_type>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GObject), "g_initially_unowned_get_type"));
+
 		public new static GLib.GType GType {
 			get {
-				return GType.Object;
+				IntPtr raw_ret = g_initially_unowned_get_type();
+				GLib.GType ret = new GLib.GType(raw_ret);
+				return ret;
 			}
 		}
 

--- a/Source/Libs/GLibSharp/Object.cs
+++ b/Source/Libs/GLibSharp/Object.cs
@@ -511,6 +511,7 @@ namespace GLib {
 		{
 			IntPtr native_name = GLib.Marshaller.StringToPtrGStrdup (name);
 			g_object_class_override_property (oclass, property_id, native_name);
+			GLib.Marshaller.Free (native_name);	
 		}
 
 		[Obsolete ("Use OverrideProperty(oclass,property_id,name)")]
@@ -527,7 +528,14 @@ namespace GLib {
 		{
 			IntPtr gobjectclass = Marshal.ReadIntPtr (o.Handle);
 			IntPtr native_name = GLib.Marshaller.StringToPtrGStrdup (name);
-			return g_object_class_find_property (gobjectclass, native_name);
+			try
+			{
+				return g_object_class_find_property (gobjectclass, native_name);
+			}
+			finally
+			{
+				GLib.Marshaller.Free (native_name);
+			}
 		}
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		delegate IntPtr d_g_object_interface_find_property(IntPtr klass, IntPtr name);
@@ -537,7 +545,14 @@ namespace GLib {
 		{
 			IntPtr g_iface = type.GetDefaultInterfacePtr ();
 			IntPtr native_name = GLib.Marshaller.StringToPtrGStrdup (name);
-			return g_object_interface_find_property (g_iface, native_name);
+			try
+			{
+				return g_object_interface_find_property (g_iface, native_name);
+			}
+			finally
+			{
+				GLib.Marshaller.Free (native_name);
+			}
 		}
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		delegate void d_g_object_class_install_property(IntPtr klass, uint prop_id, IntPtr param_spec);

--- a/Source/Libs/GLibSharp/Source.cs
+++ b/Source/Libs/GLibSharp/Source.cs
@@ -5,7 +5,7 @@
 // Copyright (c) 2002 Mike Kestner
 //
 // This program is free software; you can redistribute it and/or
-// modify it under the terms of version 2 of the Lesser GNU General 
+// modify it under the terms of version 2 of the Lesser GNU General
 // Public License as published by the Free Software Foundation.
 //
 // This program is distributed in the hope that it will be useful,
@@ -62,15 +62,12 @@ namespace GLib {
 
 		internal void Remove ()
 		{
-			Source.RemoveSourceHandler (ID);
 			real_handler = null;
 			proxy_handler = null;
 		}
 	}
 
 	public partial class Source : GLib.Opaque {
-
-		private static IDictionary<uint, SourceProxy> source_handlers = new Dictionary<uint, SourceProxy> ();
 
 		private Source () {}
 
@@ -110,57 +107,13 @@ namespace GLib {
 			GLib.Timeout.Add (50, new GLib.TimeoutHandler (info.Handler));
 		}
 
-		internal static void AddSourceHandler (uint id, SourceProxy proxy)
-		{
-			lock (Source.source_handlers) {
-				source_handlers [id] = proxy;
-			}
-		}
-
-		internal static void RemoveSourceHandler (uint id)
-		{
-			lock (Source.source_handlers) {
-				source_handlers.Remove (id);
-			}
-		}
-
-		internal static bool RemoveSourceHandler (Delegate hndlr)
-		{
-			bool result = false;
-			List<uint> keys = new List<uint> ();
-
-			lock (source_handlers) {
-				foreach (uint code in source_handlers.Keys) {
-					var p = Source.source_handlers [code];
-
-					if (p != null && p.real_handler == hndlr) {
-						keys.Add (code);
-						result = g_source_remove (code);
-					}
-				}
-
-				foreach (var key in keys) {
-					Source.RemoveSourceHandler (key);
-				}
-			}
-
-			return result;
-		}
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		delegate bool d_g_source_remove(uint tag);
 		static d_g_source_remove g_source_remove = FuncLoader.LoadFunction<d_g_source_remove>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GLib), "g_source_remove"));
 
 		public static bool Remove (uint tag)
 		{
-			// g_source_remove always returns true, so we follow that
-			bool ret = true;
-
-			lock (Source.source_handlers) {
-				if (source_handlers.Remove (tag)) {
-					ret = g_source_remove (tag);
-				}
-			}
-			return ret;
+			return g_source_remove (tag);
 		}
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		delegate IntPtr d_g_source_get_type();

--- a/Source/Libs/GLibSharp/Timeout.cs
+++ b/Source/Libs/GLibSharp/Timeout.cs
@@ -73,7 +73,9 @@ namespace GLib {
 			TimeoutProxy p = new TimeoutProxy (hndlr);
 			lock (p)
 			{
-				p.ID = g_timeout_add (interval, (TimeoutHandlerInternal) p.proxy_handler, IntPtr.Zero);
+				var gch = GCHandle.Alloc(p);
+				var userData = GCHandle.ToIntPtr(gch);
+				p.ID = g_timeout_add_full (0, interval, (TimeoutHandlerInternal) p.proxy_handler, userData, DestroyHelper.NotifyHandler);
 				Source.AddSourceHandler (p.ID, p);
 			}
 

--- a/Source/Libs/GLibSharp/Timeout.cs
+++ b/Source/Libs/GLibSharp/Timeout.cs
@@ -8,7 +8,7 @@
 // Copyright (c) 2009 Novell, Inc.
 //
 // This program is free software; you can redistribute it and/or
-// modify it under the terms of version 2 of the Lesser GNU General 
+// modify it under the terms of version 2 of the Lesser GNU General
 // Public License as published by the Free Software Foundation.
 //
 // This program is distributed in the hope that it will be useful,
@@ -62,12 +62,12 @@ namespace GLib {
 				return false;
 			}
 		}
-		
-		private Timeout () {} 
-		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-		delegate uint d_g_timeout_add(uint interval, TimeoutHandlerInternal d, IntPtr data);
-		static d_g_timeout_add g_timeout_add = FuncLoader.LoadFunction<d_g_timeout_add>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GLib), "g_timeout_add"));
 
+		private Timeout () {}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+		delegate uint d_g_timeout_add_full(int priority, uint interval, TimeoutHandlerInternal d, IntPtr data, DestroyNotify notify);
+		static d_g_timeout_add_full g_timeout_add_full = FuncLoader.LoadFunction<d_g_timeout_add_full>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GLib), "g_timeout_add_full"));
 		public static uint Add (uint interval, TimeoutHandler hndlr)
 		{
 			TimeoutProxy p = new TimeoutProxy (hndlr);
@@ -76,37 +76,36 @@ namespace GLib {
 				var gch = GCHandle.Alloc(p);
 				var userData = GCHandle.ToIntPtr(gch);
 				p.ID = g_timeout_add_full (0, interval, (TimeoutHandlerInternal) p.proxy_handler, userData, DestroyHelper.NotifyHandler);
-				Source.AddSourceHandler (p.ID, p);
 			}
 
 			return p.ID;
 		}
-		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-		delegate uint d_g_timeout_add_full(int priority, uint interval, TimeoutHandlerInternal d, IntPtr data, DestroyNotify notify);
-		static d_g_timeout_add_full g_timeout_add_full = FuncLoader.LoadFunction<d_g_timeout_add_full>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GLib), "g_timeout_add_full"));
 
 		public static uint Add (uint interval, TimeoutHandler hndlr, Priority priority)
 		{
 			TimeoutProxy p = new TimeoutProxy (hndlr);
 			lock (p)
 			{
+				var gch = GCHandle.Alloc(p);
+				var userData = GCHandle.ToIntPtr(gch);
 				p.ID = g_timeout_add_full ((int)priority, interval, (TimeoutHandlerInternal) p.proxy_handler, IntPtr.Zero, null);
-				Source.AddSourceHandler (p.ID, p);
 			}
 
 			return p.ID;
 		}
+
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-		delegate uint d_g_timeout_add_seconds(uint interval, TimeoutHandlerInternal d, IntPtr data);
-		static d_g_timeout_add_seconds g_timeout_add_seconds = FuncLoader.LoadFunction<d_g_timeout_add_seconds>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GLib), "g_timeout_add_seconds"));
+		delegate uint d_g_timeout_add_seconds_full(int priority, uint interval, TimeoutHandlerInternal d, IntPtr data, DestroyNotify notify);
+		static d_g_timeout_add_seconds_full g_timeout_add_seconds_full = FuncLoader.LoadFunction<d_g_timeout_add_seconds_full>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GLib), "g_timeout_add_seconds_full"));
 
 		public static uint AddSeconds (uint interval, TimeoutHandler hndlr)
 		{
 			TimeoutProxy p = new TimeoutProxy (hndlr);
 			lock (p)
 			{
-				p.ID = g_timeout_add_seconds (interval, (TimeoutHandlerInternal) p.proxy_handler, IntPtr.Zero);
-				Source.AddSourceHandler (p.ID, p);
+				var gch = GCHandle.Alloc(p);
+				var userData = GCHandle.ToIntPtr(gch);
+				p.ID = g_timeout_add_seconds_full (0, interval, (TimeoutHandlerInternal) p.proxy_handler, userData, DestroyHelper.NotifyHandler);
 			}
 
 			return p.ID;
@@ -115,11 +114,6 @@ namespace GLib {
 		public static void Remove (uint id)
 		{
 			Source.Remove (id);
-		}
-
-		public static bool Remove (TimeoutHandler hndlr)
-		{
-			return Source.RemoveSourceHandler (hndlr);
 		}
 	}
 }

--- a/Source/Libs/GLibSharp/ToggleRef.cs
+++ b/Source/Libs/GLibSharp/ToggleRef.cs
@@ -38,8 +38,7 @@ namespace GLib {
 			gch = GCHandle.Alloc (this);
 			reference = target;
 			g_object_add_toggle_ref (target.Handle, ToggleNotifyCallback, (IntPtr) gch);
-			if (target.owned && !(target is InitiallyUnowned))
-				g_object_unref (target.Handle);
+			g_object_unref (target.Handle);
 		}
 
 		public IntPtr Handle {
@@ -67,9 +66,7 @@ namespace GLib {
 		}
 
   		void Free ()
-		{
-			Target?.FreeSignals ();
-
+  		{
 			if (hardened)
 				g_object_unref (handle);
 			else

--- a/Source/Libs/GLibSharp/Value.cs
+++ b/Source/Libs/GLibSharp/Value.cs
@@ -6,7 +6,7 @@
 // Copyright (c) 2003-2004 Novell, Inc.
 //
 // This program is free software; you can redistribute it and/or
-// modify it under the terms of version 2 of the Lesser GNU General 
+// modify it under the terms of version 2 of the Lesser GNU General
 // Public License as published by the Free Software Foundation.
 //
 // This program is distributed in the hope that it will be useful,
@@ -76,12 +76,12 @@ namespace GLib {
 
 		public Value (uint val) : this (GType.UInt)
 		{
-			g_value_set_uint (ref this, val); 
+			g_value_set_uint (ref this, val);
 		}
 
 		public Value (ushort val) : this (GType.UInt)
 		{
-			g_value_set_uint (ref this, val); 
+			g_value_set_uint (ref this, val);
 		}
 
 		public Value (long val) : this (GType.Int64)
@@ -107,7 +107,7 @@ namespace GLib {
 		public Value (string val) : this (GType.String)
 		{
 			IntPtr native_val = GLib.Marshaller.StringToPtrGStrdup (val);
-			g_value_set_string (ref this, native_val); 
+			g_value_set_string (ref this, native_val);
 			GLib.Marshaller.Free (native_val);
 		}
 
@@ -118,7 +118,7 @@ namespace GLib {
 
 		public Value (IntPtr val) : this (GType.Pointer)
 		{
-			g_value_set_pointer (ref this, val); 
+			g_value_set_pointer (ref this, val);
 		}
 
 		public Value (Variant variant) : this (GType.Variant)
@@ -179,7 +179,7 @@ namespace GLib {
 			Marshal.FreeHGlobal (native_array);
 		}
 
-		public void Dispose () 
+		public void Dispose ()
 		{
 			g_value_unset (ref this);
 		}
@@ -254,6 +254,12 @@ namespace GLib {
 			return g_value_get_double (ref val);
 		}
 
+		public static explicit operator GLib.GType (Value val)
+		{
+			return g_value_get_gtype (ref val);
+		}
+
+
 		public static explicit operator string (Value val)
 		{
 			IntPtr str = g_value_get_string (ref val);
@@ -309,7 +315,7 @@ namespace GLib {
 		object ToRegisteredType () {
 			Type t = GLib.GType.LookupType (type);
 			ConstructorInfo ci = null;
-			
+
 			try {
 				while (ci == null && t != null) {
 					if (!t.IsAbstract)
@@ -323,14 +329,14 @@ namespace GLib {
 
 			if (ci == null)
 				throw new Exception ("Unknown type " + new GType (type).ToString ());
-			
+
 			return ci.Invoke (new object[] {this});
 		}
 
 		void FromRegisteredType (object val) {
 			Type t = GLib.GType.LookupType (type);
 			MethodInfo mi = null;
-			
+
 			try {
 				while (mi == null && t != null) {
 					mi = t.GetMethod ("SetGValue", new Type[] { Type.GetType ("GLib.Value&") });
@@ -342,10 +348,10 @@ namespace GLib {
 			} catch (Exception) {
 				mi = null;
 			}
-			
+
 			if (mi == null)
 				throw new Exception ("Unknown type " + new GType (type).ToString ());
-			
+
 			object[] parameters = new object[] { this };
 			mi.Invoke (val, parameters);
 			this = (GLib.Value) parameters[0];
@@ -410,7 +416,7 @@ namespace GLib {
 		object ToEnum ()
 		{
 			Type t = GType.LookupType (type);
-			
+
 			if (t == null) {
 				if (HoldsFlags)
 					return g_value_get_flags (ref this);
@@ -606,7 +612,7 @@ namespace GLib {
 
 			if (spec_ptr == IntPtr.Zero)
 				throw new Exception (String.Format ("No property with name '{0}' in type '{1}'", name, gtype.ToString()));
-			
+
 			ParamSpec spec = new ParamSpec (spec_ptr);
 			g_value_init (ref this, spec.ValueType.Val);
 		}
@@ -685,7 +691,7 @@ namespace GLib {
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		delegate void d_g_value_set_variant(ref Value val, IntPtr data);
 		static d_g_value_set_variant g_value_set_variant = FuncLoader.LoadFunction<d_g_value_set_variant>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GObject), "g_value_set_variant"));
-		
+
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		delegate bool d_g_value_get_boolean(ref Value val);
 		static d_g_value_get_boolean g_value_get_boolean = FuncLoader.LoadFunction<d_g_value_get_boolean>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GObject), "g_value_get_boolean"));
@@ -704,6 +710,9 @@ namespace GLib {
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		delegate float d_g_value_get_float(ref Value val);
 		static d_g_value_get_float g_value_get_float = FuncLoader.LoadFunction<d_g_value_get_float>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GObject), "g_value_get_float"));
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+		delegate IntPtr d_g_value_get_gtype(ref Value val);
+		static d_g_value_get_type g_value_get_gtype = FuncLoader.LoadFunction<d_g_value_get_variant>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GObject), "g_value_get_gtype"));
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		delegate int d_g_value_get_int(ref Value val);
 		static d_g_value_get_int g_value_get_int = FuncLoader.LoadFunction<d_g_value_get_int>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GObject), "g_value_get_int"));

--- a/Source/Libs/GLibSharp/Value.cs
+++ b/Source/Libs/GLibSharp/Value.cs
@@ -711,8 +711,8 @@ namespace GLib {
 		delegate float d_g_value_get_float(ref Value val);
 		static d_g_value_get_float g_value_get_float = FuncLoader.LoadFunction<d_g_value_get_float>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GObject), "g_value_get_float"));
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-		delegate IntPtr d_g_value_get_gtype(ref Value val);
-		static d_g_value_get_type g_value_get_gtype = FuncLoader.LoadFunction<d_g_value_get_variant>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GObject), "g_value_get_gtype"));
+		delegate GLib.GType d_g_value_get_gtype(ref Value val);
+		static d_g_value_get_gtype g_value_get_gtype = FuncLoader.LoadFunction<d_g_value_get_gtype>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GObject), "g_value_get_gtype"));
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		delegate int d_g_value_get_int(ref Value val);
 		static d_g_value_get_int g_value_get_int = FuncLoader.LoadFunction<d_g_value_get_int>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GObject), "g_value_get_int"));

--- a/Source/Libs/GLibSharp/ValueArray.cs
+++ b/Source/Libs/GLibSharp/ValueArray.cs
@@ -43,7 +43,7 @@ namespace GLib {
 
 		public ValueArray (IntPtr raw)
 		{
-			handle = raw;
+			handle = g_value_array_copy (raw);
 		}
 		
 		~ValueArray ()

--- a/Source/Libs/GtkSharp/GtkSharp.metadata
+++ b/Source/Libs/GtkSharp/GtkSharp.metadata
@@ -1002,4 +1002,8 @@
   <move-node path="/api/namespace/class[@cname='GtkGlobal']/method[@name='PaintVline']">/api/namespace/object[@cname='GtkStyle']</move-node>
   <remove-node path="/api/namespace/struct[@cname='IconSize']" />
   <remove-node path="/api/namespace/struct[@cname='Range']" />
+
+	<!-- Mark reserved fields as padding -->
+	<attr path="//*[contains(@cname, 'gtk_reserved')]" name="padding">true</attr>
+	<attr path="//*[contains(@vm, 'gtk_reserved')]" name="padding">true</attr>
 </metadata>

--- a/Source/Libs/GtkSharp/Widget.cs
+++ b/Source/Libs/GtkSharp/Widget.cs
@@ -391,16 +391,11 @@ namespace Gtk {
 		{
 			if (Handle == IntPtr.Zero)
 				return;
-
-			if (disposing)
-				gtk_widget_destroy (Handle);
-
 			InternalDestroyed -= NativeDestroyHandler;
-
 			base.Dispose (disposing);
 		}
 
-		protected override IntPtr Raw {
+	protected override IntPtr Raw {
 			get {
 				return base.Raw;
 			}
@@ -414,9 +409,12 @@ namespace Gtk {
 		delegate void d_gtk_widget_destroy(IntPtr raw);
 		static d_gtk_widget_destroy gtk_widget_destroy = FuncLoader.LoadFunction<d_gtk_widget_destroy>(FuncLoader.GetProcAddress(GLibrary.Load(Library.Gtk), "gtk_widget_destroy"));
 
-		[Obsolete("Use Dispose")]
 		public virtual void Destroy ()
 		{
+			if (Handle == IntPtr.Zero)
+				return;
+			gtk_widget_destroy (Handle);
+			InternalDestroyed -= NativeDestroyHandler;
 		}
 	}
 }

--- a/Source/Libs/GtkSourceSharp/Buffer.cs
+++ b/Source/Libs/GtkSourceSharp/Buffer.cs
@@ -5,7 +5,6 @@
     {
         public Buffer() : base(IntPtr.Zero)
         {
-            owned = true;
             Raw = gtk_source_buffer_new(IntPtr.Zero);
         }
     }

--- a/Source/Libs/Shared/Gapi.xsd
+++ b/Source/Libs/Shared/Gapi.xsd
@@ -182,6 +182,7 @@
             <xs:element name="method" maxOccurs="unbounded" minOccurs="0">
                 <xs:complexType>
                     <xs:attribute name="vm" type="xs:string" use="optional"/>
+                    <xs:attribute name="padding" type="xs:string" use="optional"/>
                     <xs:attribute name="signal_vm" type="xs:string" use="optional"/>
                 </xs:complexType>
             </xs:element>
@@ -211,6 +212,7 @@
 	<xs:complexType name="fieldType">
         <xs:attribute name="name" type="xs:string"/>
         <xs:attribute name="cname" type="xs:string"/>
+        <xs:attribute name="padding" type="xs:boolean" use="optional"/>
         <xs:attribute name="type" type="xs:string"/>
         <xs:attribute name="array" type="xs:boolean" use="optional"/>
         <xs:attribute name="array_len" type="xs:positiveInteger" use="optional"/>

--- a/Source/Tools/GapiCodegen/ClassBase.cs
+++ b/Source/Tools/GapiCodegen/ClassBase.cs
@@ -46,6 +46,12 @@ namespace GtkSharp.Generation {
 		private Dictionary<string, Ctor> clash_map;
 		private bool deprecated = false;
 		private bool isabstract = false;
+		public bool nameConstructors {
+			get {
+				return Elem.GetAttributeAsBoolean("name_constructors");
+			}
+		}
+
 
 		public IDictionary<string, Method> Methods {
 			get {
@@ -563,7 +569,11 @@ namespace GtkSharp.Generation {
 			clash_map = new Dictionary<string, Ctor>();
 
 			foreach (Ctor ctor in ctors) {
-				if (clash_map.ContainsKey (ctor.Signature.Types)) {
+				if (nameConstructors) {
+					ctor.IsStatic = true;
+					if (Parent != null && Parent.HasStaticCtor (ctor.StaticName))
+						ctor.Modifiers = "new ";
+				} else if (clash_map.ContainsKey (ctor.Signature.Types)) {
 					Ctor clash = clash_map [ctor.Signature.Types];
 					Ctor alter = ctor.Preferred ? clash : ctor;
 					alter.IsStatic = true;

--- a/Source/Tools/GapiCodegen/ClassBase.cs
+++ b/Source/Tools/GapiCodegen/ClassBase.cs
@@ -252,8 +252,11 @@ namespace GtkSharp.Generation {
 				var field = _fields[i];
 				next = _fields.Count > i +1 ? _fields[i + 1] : null;
 
+
 				prev = field.Generate(gen_info, "\t\t\t\t\t", prev, next, cs_parent_struct,
 						field_alignment_structures_writer);
+				if (field.IsPadding)
+					continue;
 				var union = field as UnionABIField;
 				if (union == null && gen_info.CAbiWriter != null && !field.IsBitfield) {
 					gen_info.AbiWriter.WriteLine("\t\t\tConsole.WriteLine(\"\\\"{0}.{3}\\\": \\\"\" + {1}.{2}." + info_name + ".GetFieldOffset(\"{3}\") + \"\\\"\");", structname, NS, Name, field.CName);

--- a/Source/Tools/GapiCodegen/Ctor.cs
+++ b/Source/Tools/GapiCodegen/Ctor.cs
@@ -38,6 +38,7 @@ namespace GtkSharp.Generation {
 			preferred = elem.GetAttributeAsBoolean ("preferred");
 			if (implementor is ObjectGen)
 				needs_chaining = true;
+
 			name = implementor.Name;
 		}
 

--- a/Source/Tools/GapiCodegen/Ctor.cs
+++ b/Source/Tools/GapiCodegen/Ctor.cs
@@ -150,10 +150,7 @@ namespace GtkSharp.Generation {
 					sw.WriteLine ("\t\t\t}");
 				}
 	
-				Body.Initialize(gen_info, false, false, "");
-				if (container_type is ObjectGen) {
-					sw.WriteLine ("\t\t\towned = true;");
-				}
+				Body.Initialize(gen_info, false, false, ""); 
 				sw.WriteLine("\t\t\t{0} = {1}({2});", container_type.AssignToName, CName, Body.GetCallString (false));
 				Body.Finish (sw, "");
 				Body.HandleException (sw, "");

--- a/Source/Tools/GapiCodegen/StructField.cs
+++ b/Source/Tools/GapiCodegen/StructField.cs
@@ -152,8 +152,8 @@ namespace GtkSharp.Generation {
 
 		public bool IsPadding {
 			get {
-				if (elem.GetAttributeAsBoolean ("is-padding"))
-					return elem.GetAttributeAsBoolean ("is-padding");
+				if (elem.GetAttributeAsBoolean ("padding"))
+					return elem.GetAttributeAsBoolean ("padding");
 
 				return (elem.GetAttribute ("access") == "private" && (
 					CName.StartsWith ("dummy") || CName.StartsWith ("padding")));

--- a/Source/Tools/GapiCodegen/StructField.cs
+++ b/Source/Tools/GapiCodegen/StructField.cs
@@ -89,7 +89,9 @@ namespace GtkSharp.Generation {
 				string wrapped_name = SymbolTable.Table.MangleName (CName);
 				IGeneratable gen = table [CType];
 
-				if (IsArray || gen is IAccessor)
+				if (IsArray && IsNullTermArray)
+					return StudlyName + "Ptr";
+				else if (IsArray || gen is IAccessor)
 					return Access == "public" ? StudlyName : Name;
 				else if (IsBitfield)
 					return Name;

--- a/Source/Tools/GapiCodegen/SymbolTable.cs
+++ b/Source/Tools/GapiCodegen/SymbolTable.cs
@@ -232,6 +232,7 @@ namespace GtkSharp.Generation {
 				return trim_type;
 			
 			if (trim_type.StartsWith("const-")) return trim_type.Substring(6);
+			if (trim_type.StartsWith("const ")) return trim_type.Substring(6);
 			return trim_type;
 		}
 


### PR DESCRIPTION
This backports a serie of patches from GlibSharp as we would like to base the GStreamer binding on top of this GtkSharp implementation and we have fixed quite a few things in there. Check commits independently for more details but the most import change is the proper fix of floating reference management (fixing https://github.com/GtkSharp/GtkSharp/issues/197).