### PR TITLE
IScrollable: GetBorder border as out param

### DIFF
--- a/Source/Libs/GtkSharp/GtkSharp.metadata
+++ b/Source/Libs/GtkSharp/GtkSharp.metadata
@@ -979,6 +979,9 @@
   <attr path="/api/namespace/struct[@cname='GtkTextLogAttrCache']" name="hidden">1</attr>
   <attr path="/api/namespace/struct[@cname='GtkWidgetAuxInfo']" name="hidden">1</attr>
   <attr path="/api/namespace/struct[@cname='GtkWindowGeometryInfo']" name="hidden">1</attr>
+  
+  <attr path="/api/namespace/interface[@cname='GtkScrollable']/method[@name='GetBorder']/*/parameter[@name='border']" name="pass_as">out</attr> 
+   
   <move-node path="/api/namespace/class[@cname='GtkBindings_']/method[@name='BindingsActivate']">/api/namespace/class[@cname='GtkGlobal']</move-node>
   <move-node path="/api/namespace/class[@cname='GtkGlobal']/method[@name='PaintArrow']">/api/namespace/object[@cname='GtkStyle']</move-node>
   <move-node path="/api/namespace/class[@cname='GtkGlobal']/method[@name='PaintBoxGap']">/api/namespace/object[@cname='GtkStyle']</move-node>


### PR DESCRIPTION
changes

```c#
IScrollable.bool GetBorder(Gtk.Border border);
```
to
```c#
IScrollable.bool GetBorder(out Gtk.Border border);
```

as of 

https://github.com/GNOME/gtk/blob/b534752d5c0fc69a94fe9fe51abe1c047afa57c5/gtk/gtkscrollable.c#L292-L308

should be an **out** parameter
fix of https://github.com/GtkSharp/GtkSharp/issues/200
