### PR TITLE
Don't add reference to PixbufHandle

### DIFF
--- a/Source/Libs/GdkSharp/PixbufLoader.cs
+++ b/Source/Libs/GdkSharp/PixbufLoader.cs
@@ -33,7 +33,7 @@ namespace Gdk {
 
 		internal IntPtr PixbufHandle {
 			get {
-				return g_object_ref (gdk_pixbuf_loader_get_pixbuf (Handle));
+				return gdk_pixbuf_loader_get_pixbuf (Handle);
 			}
 		}
 


### PR DESCRIPTION
The `PixbufLoader.PixbufHandle` property is only used when creating new Pixbuf objects, which when you assign the handle to Raw it adds a reference already.  So we shouldn't add a reference when accessing the property.

Fixes #186

Fixes https://github.com/picoe/Eto/issues/1771