### PR TITLE
MonoDevelop.GtkSharp.Addin.csproj: make CI happy

### DIFF
--- a/Source/Addins/MonoDevelop.GtkSharp.Addin/MonoDevelop.GtkSharp.Addin.csproj
+++ b/Source/Addins/MonoDevelop.GtkSharp.Addin/MonoDevelop.GtkSharp.Addin.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net471</TargetFramework>
     <OutputPath>..\..\..\BuildOutput\Addins\MonoDevelop\</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="MonoDevelop.Addins" Version="0.4.4" />
+    <PackageReference Include="MonoDevelop.Addins" Version="0.4.7" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="Templates\File\Dialog.CS.xft.xml" />


### PR DESCRIPTION
building MonoDevelop.GtkSharp.Addin fails in CI
probably cause of updates in Mono & installed dotnet 5.0
works if:
adjust TargetFramework to net471  & adjust MonoDevelop.Addins to version 0.4.7