### PR TITLE
Disposing of Widgets and Signals

### DIFF
--- a/Source/Libs/GLibSharp/Idle.cs
+++ b/Source/Libs/GLibSharp/Idle.cs
@@ -54,7 +54,7 @@ namespace GLib {
 					{
 						lock (this)
 						{
-							Remove ();
+							Dispose();
 						}
 					}
 					return cont;

--- a/Source/Libs/GLibSharp/Timeout.cs
+++ b/Source/Libs/GLibSharp/Timeout.cs
@@ -52,7 +52,7 @@ namespace GLib {
 					{
 						lock (this)
 						{
-							Remove ();
+							Dispose();
 						}
 					}
 					return cont;

--- a/Source/Libs/GtkSharp/Builder.cs
+++ b/Source/Libs/GtkSharp/Builder.cs
@@ -151,6 +151,16 @@ namespace Gtk {
 			GLib.Marshaller.Free (native_name);
 			return raw_ret;
 		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+		delegate IntPtr d_g_object_ref(IntPtr raw);
+		static d_g_object_ref g_object_ref = FuncLoader.LoadFunction<d_g_object_ref>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GObject), "g_object_ref"));
+
+		public IntPtr GetRawOwnedObject(string name) {
+			IntPtr raw_ret = GetRawObject (name);
+			g_object_ref (raw_ret);
+			return raw_ret;
+		}
 		
 		public Builder (System.IO.Stream s) : this (s, null)
 		{

--- a/Source/Libs/GtkSharp/MessageDialog.cs
+++ b/Source/Libs/GtkSharp/MessageDialog.cs
@@ -26,7 +26,7 @@ namespace Gtk {
 		delegate IntPtr d_gtk_message_dialog_new_with_markup(IntPtr parent_window, DialogFlags flags, MessageType type, ButtonsType bt, IntPtr msg, IntPtr args);
 		static d_gtk_message_dialog_new_with_markup gtk_message_dialog_new_with_markup = FuncLoader.LoadFunction<d_gtk_message_dialog_new_with_markup>(FuncLoader.GetProcAddress(GLibrary.Load(Library.Gtk), "gtk_message_dialog_new_with_markup"));
 
-		public MessageDialog (Gtk.Window parent_window, DialogFlags flags, MessageType type, ButtonsType bt, bool use_markup, string format, params object[] args)
+		public MessageDialog (Gtk.Window parent_window, DialogFlags flags, MessageType type, ButtonsType bt, bool use_markup, string format, params object[] args) : base (IntPtr.Zero)
 		{
 			IntPtr p = (parent_window != null) ? parent_window.Handle : IntPtr.Zero;
 


### PR DESCRIPTION
This patch fixes some issues with disposing of widget and moving disposing of signals to the main thread.

Destroy should never be called, unless it is a TopLevel widget. Dispose will automatically call Destroy on TopLevel widgets.

It also introduce a new GetRawOwnedObject that should be used if it is not a toplevel widget, you are creating.