### PR TITLE
Revert "Don't add reference to PixbufHandle"

### DIFF
--- a/Source/Libs/GdkSharp/PixbufLoader.cs
+++ b/Source/Libs/GdkSharp/PixbufLoader.cs
@@ -33,7 +33,7 @@ namespace Gdk {
 
 		internal IntPtr PixbufHandle {
 			get {
-				return gdk_pixbuf_loader_get_pixbuf (Handle);
+				return g_object_ref (gdk_pixbuf_loader_get_pixbuf (Handle));
 			}
 		}
 


### PR DESCRIPTION
Reverts GtkSharp/GtkSharp#203

Causes problems when loading pixbuf from stream so reverting it.

Fixes #216