### PR TITLE
Fixed some APIs according to GTK docs

### DIFF
--- a/Source/Libs/GioSharp/GioSharp.metadata
+++ b/Source/Libs/GioSharp/GioSharp.metadata
@@ -54,6 +54,12 @@
   <attr path="/api/namespace/interface[@cname='GActionGroup']/method[@name='ActionEnabledChanged']" name="name">EmitActionEnabledChanged</attr>
   <attr path="/api/namespace/interface[@cname='GActionGroup']/method[@name='ActionRemoved']" name="name">EmitActionRemoved</attr>
   <attr path="/api/namespace/interface[@cname='GActionGroup']/method[@name='ActionStateChanged']" name="name">EmitActionStateChanged</attr>
+  <attr path="/api/namespace/interface[@cname='GActionGroup']/method[@name='ListActions']/return-type" name="null_term_array">true</attr>
+  <attr path="/api/namespace/interface[@cname='GActionGroup']/method[@name='ListActions']/return-type" name="owned">true</attr>
+  <attr path="/api/namespace/interface[@cname='GActionGroup']/method[@name='ListActions']/return-type" name="elements_owned">true</attr>
+  <attr path="/api/namespace/interface[@cname='GActionGroup']/virtual_method[@name='ListActions']/return-type" name="null_term_array">true</attr>
+  <attr path="/api/namespace/interface[@cname='GActionGroup']/virtual_method[@name='ListActions']/return-type" name="owned">true</attr>
+  <attr path="/api/namespace/interface[@cname='GActionGroup']/virtual_method[@name='ListActions']/return-type" name="elements_owned">true</attr>
   <attr path="/api/namespace/interface[@cname='GAppInfo']" name="consume_only">1</attr>
   <attr path="/api/namespace/interface[@cname='GAppInfo']/method[@name='CanRemoveSupportsType']" name="name">GetCanRemoveSupportsType</attr>
   <attr path="/api/namespace/interface[@cname='GAppInfo']/method[@name='GetAll']" name="hidden">1</attr>

--- a/Source/Libs/GtkSharp/GtkSharp.metadata
+++ b/Source/Libs/GtkSharp/GtkSharp.metadata
@@ -364,6 +364,8 @@
   <attr path="/api/namespace/object[@cname='GtkEntry']/property[@name='Editable']" name="hidden">1</attr>
   <remove-node path="/api/namespace/object[@cname='GtkEntry']/property[@name='InvisibleChar']" />
   <remove-node path="/api/namespace/object[@cname='GtkEntry']/property[@name='InnerBorder']" />
+  <attr path="/api/namespace/object[@cname='GtkEntry']/method[@name='GetIconArea']/parameters/parameter[@name='icon_area']" name="pass_as">out</attr>
+  <attr path="/api/namespace/object[@cname='GtkEntry']/method[@name='GetTextArea']/parameters/parameter[@name='text_area']" name="pass_as">out</attr>
   <attr path="/api/namespace/object[@cname='GtkEntry']/signal[@name='Activate']" name="name">Activated</attr>
   <attr path="/api/namespace/object[@cname='GtkEntry']/signal[@name='CopyClipboard']" name="name">ClipboardCopied</attr>
   <attr path="/api/namespace/object[@cname='GtkEntry']/signal[@name='CutClipboard']" name="name">ClipboardCut</attr>
@@ -1006,7 +1008,7 @@
   <remove-node path="/api/namespace/struct[@cname='IconSize']" />
   <remove-node path="/api/namespace/struct[@cname='Range']" />
 
-	<!-- Mark reserved fields as padding -->
-	<attr path="//*[contains(@cname, 'gtk_reserved')]" name="padding">true</attr>
-	<attr path="//*[contains(@vm, 'gtk_reserved')]" name="padding">true</attr>
+  <!-- Mark reserved fields as padding -->
+  <attr path="//*[contains(@cname, 'gtk_reserved')]" name="padding">true</attr>
+  <attr path="//*[contains(@vm, 'gtk_reserved')]" name="padding">true</attr>
 </metadata>


### PR DESCRIPTION
* [g_action_group_list_actions](https://developer.gnome.org/gio/stable/GActionGroup.html#g-action-group-list-actions)
Return type is owning NULL-terminated array
I suppose this fixes #165

* [gtk_entry_get_icon_area](https://developer.gnome.org/gtk3/stable/GtkEntry.html#gtk-entry-get-icon-area)
Parameter `icon_area` is [out]

* [gtk_entry_get_text_area](https://developer.gnome.org/gtk3/stable/GtkEntry.html#gtk-entry-get-text-area)
Parameter `text_area` is [out]
