### PR TITLE
Correct flag check in Signal.Handler. Fixes issues for glib2 2.66 -> 2.68 update

### DIFF
--- a/Source/Libs/GLibSharp/Signal.cs
+++ b/Source/Libs/GLibSharp/Signal.cs
@@ -211,11 +211,10 @@ namespace GLib {
 
 		public Delegate Handler {
 			get {
-				InvocationHint hint = (InvocationHint) Marshal.PtrToStructure (g_signal_get_invocation_hint (obj.Handle), typeof (InvocationHint));
-				if (hint.run_type == Flags.RunFirst)
-					return before_handler;
-				else
-					return after_handler;
+				var hint = (InvocationHint) Marshal.PtrToStructure (g_signal_get_invocation_hint (obj.Handle), typeof (InvocationHint));
+				return hint.run_type.HasFlag(Flags.RunFirst)
+					? before_handler
+					: after_handler;
 			}
 		}
 


### PR DESCRIPTION
After glib2 update to 2.68,  Signal.Flags marshaling is broken, ex value Flags.RunFirst is returned as RunFirst(100000000000000001b)
![SignalFlags](https://user-images.githubusercontent.com/7662087/112722486-8c3e2b80-8f12-11eb-989c-8591f18be1bf.png)

Fixes picoe/Eto#1914

Env: 
 - ArchLinux
 - glib2-2.68.0-5
 - dotnet-runtime 5.0.4.sdk104-1

ps. not sure what they changed, it's possible that other structures are affected as well