### PR TITLE
Pixbuf Windows fixes (utf8 suffix)

### DIFF
--- a/Source/Libs/GdkSharp/GdkSharp.metadata
+++ b/Source/Libs/GdkSharp/GdkSharp.metadata
@@ -87,8 +87,15 @@
   <attr path="/api/namespace/object[@cname='GdkKeymap']/method[@name='GetEntriesForKeycode']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GdkKeymap']/method[@name='GetEntriesForKeyval']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GdkPixbuf']/constructor[@cname='gdk_pixbuf_new_from_data']" name="hidden">1</attr>
-  <attr path="/api/namespace/object[@cname='GdkPixbuf']/constructor[@cname='gdk_pixbuf_new_from_file']" name="preferred">1</attr>
+  <attr path="/api/namespace/object[@cname='GdkPixbuf']/constructor[@cname='gdk_pixbuf_new_from_file']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GdkPixbuf']/constructor[@cname='gdk_pixbuf_new_from_file_utf8']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GdkPixbuf']/constructor[@cname='gdk_pixbuf_new_from_file_at_scale']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GdkPixbuf']/constructor[@cname='gdk_pixbuf_new_from_file_at_scale_utf8']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GdkPixbuf']/constructor[@cname='gdk_pixbuf_new_from_file_at_size']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GdkPixbuf']/constructor[@cname='gdk_pixbuf_new_from_file_at_size_utf8']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GdkPixbuf']/constructor[@cname='gdk_pixbuf_new_from_inline']/*/*[@name='data']" name="array">1</attr>
+  <attr path="/api/namespace/object[@cname='GdkPixbuf']/constructor[@cname='gdk_pixbuf_new_from_resource']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GdkPixbuf']/constructor[@cname='gdk_pixbuf_new_from_resource_at_scale']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GdkPixbuf']/constructor[@cname='gdk_pixbuf_new_from_xpm_data']/*/*[@name='data']" name="array">1</attr>
   <attr path="/api/namespace/object[@cname='GdkPixbuf']/method[@name='AddAlpha']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GdkPixbuf']/method[@name='ApplyEmbeddedOrientation']/return-type" name="owned">true</attr>
@@ -97,6 +104,7 @@
   <attr path="/api/namespace/object[@cname='GdkPixbuf']/method[@name='GetPixels']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GdkPixbuf']/method[@name='Save']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GdkPixbuf']/method[@name='Savev']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GdkPixbuf']/method[@name='SavevUtf8']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GdkPixbuf']/method[@name='SaveToBuffer']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GdkPixbuf']/method[@name='SaveToBufferv']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GdkPixbuf']/method[@name='SaveToCallback']" name="hidden">1</attr>
@@ -107,6 +115,9 @@
   <attr path="/api/namespace/object[@cname='GdkPixbuf']/property" name="readable">true</attr>
   <attr path="/api/namespace/object[@cname='GdkPixbuf']/property" name="writeable">true</attr>
   <attr path="/api/namespace/object[@cname='GdkPixbuf']/property" name="construct-only">true</attr>
+  <attr path="/api/namespace/object[@cname='GdkPixbufAnimation']/constructor[@cname='gdk_pixbuf_animation_new_from_file']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GdkPixbufAnimation']/constructor[@cname='gdk_pixbuf_animation_new_from_file_utf8']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GdkPixbufAnimation']/constructor[@cname='gdk_pixbuf_animation_new_from_resource']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GdkPixbufLoader']/method[@name='Write']/*/*[@name='buf']" name="array">1</attr>
   <attr path="/api/namespace/object[@cname='GdkScreen']/method[@name='GetFontOptions']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GdkScreen']/method[@name='GetMonitorGeometry']/*/*[@type='GdkRectangle*']" name="pass_as">out</attr>

--- a/Source/Libs/GdkSharp/Pixbuf.cs
+++ b/Source/Libs/GdkSharp/Pixbuf.cs
@@ -39,6 +39,48 @@ namespace Gdk {
 
 	public partial class Pixbuf {
 
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+		delegate IntPtr d_gdk_pixbuf_new_from_file(IntPtr filename, out IntPtr error);
+		static d_gdk_pixbuf_new_from_file gdk_pixbuf_new_from_file = FuncLoader.LoadFunction<d_gdk_pixbuf_new_from_file>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GdkPixbuf), 
+			FuncLoader.IsWindows ? "gdk_pixbuf_new_from_file_utf8" : "gdk_pixbuf_new_from_file"));
+
+		public Pixbuf(string filename) : base(IntPtr.Zero)
+		{
+			IntPtr native_filename = GLib.Marshaller.StringToPtrGStrdup(filename);
+			IntPtr error = IntPtr.Zero;
+			Raw = gdk_pixbuf_new_from_file(native_filename, out error);
+			GLib.Marshaller.Free(native_filename);
+			if (error != IntPtr.Zero) throw new GLib.GException(error);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+		delegate IntPtr d_gdk_pixbuf_new_from_file_at_scale(IntPtr filename, int width, int height, bool preserve_aspect_ratio, out IntPtr error);
+		static d_gdk_pixbuf_new_from_file_at_scale gdk_pixbuf_new_from_file_at_scale = FuncLoader.LoadFunction<d_gdk_pixbuf_new_from_file_at_scale>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GdkPixbuf),
+			FuncLoader.IsWindows ? "gdk_pixbuf_new_from_file_at_scale_utf8" : "gdk_pixbuf_new_from_file_at_scale"));
+
+		public Pixbuf(string filename, int width, int height, bool preserve_aspect_ratio) : base(IntPtr.Zero)
+		{
+			IntPtr native_filename = GLib.Marshaller.StringToPtrGStrdup(filename);
+			IntPtr error = IntPtr.Zero;
+			Raw = gdk_pixbuf_new_from_file_at_scale(native_filename, width, height, preserve_aspect_ratio, out error);
+			GLib.Marshaller.Free(native_filename);
+			if (error != IntPtr.Zero) throw new GLib.GException(error);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+		delegate IntPtr d_gdk_pixbuf_new_from_file_at_size(IntPtr filename, int width, int height, out IntPtr error);
+		static d_gdk_pixbuf_new_from_file_at_size gdk_pixbuf_new_from_file_at_size = FuncLoader.LoadFunction<d_gdk_pixbuf_new_from_file_at_size>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GdkPixbuf),
+			FuncLoader.IsWindows ? "gdk_pixbuf_new_from_file_at_size_utf8" : "gdk_pixbuf_new_from_file_at_size"));
+
+		public Pixbuf(string filename, int width, int height) : base(IntPtr.Zero)
+		{
+			IntPtr native_filename = GLib.Marshaller.StringToPtrGStrdup(filename);
+			IntPtr error = IntPtr.Zero;
+			Raw = gdk_pixbuf_new_from_file_at_size(native_filename, width, height, out error);
+			GLib.Marshaller.Free(native_filename);
+			if (error != IntPtr.Zero) throw new GLib.GException(error);
+		}
+
 		public Pixbuf (System.IO.Stream stream) : base (IntPtr.Zero)
 		{
 			using (PixbufLoader pl = new PixbufLoader (stream)) {
@@ -202,12 +244,12 @@ namespace Gdk {
 		delegate IntPtr d_gdk_pixbuf_get_pixels(IntPtr raw);
 		static d_gdk_pixbuf_get_pixels gdk_pixbuf_get_pixels = FuncLoader.LoadFunction<d_gdk_pixbuf_get_pixels>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GdkPixbuf), "gdk_pixbuf_get_pixels"));
 
-                public IntPtr Pixels {
-                	get {
-                		IntPtr ret = gdk_pixbuf_get_pixels (Handle);
-                		return ret;
-                	}
-                }
+		public IntPtr Pixels {
+			get {
+				IntPtr ret = gdk_pixbuf_get_pixels (Handle);
+				return ret;
+			}
+		}
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		delegate IntPtr d_gdk_pixbuf_get_formats();
 		static d_gdk_pixbuf_get_formats gdk_pixbuf_get_formats = FuncLoader.LoadFunction<d_gdk_pixbuf_get_formats>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GdkPixbuf), "gdk_pixbuf_get_formats"));
@@ -226,7 +268,8 @@ namespace Gdk {
 		}
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		delegate bool d_gdk_pixbuf_save(IntPtr raw, IntPtr filename, IntPtr type, out IntPtr error, IntPtr dummy);
-		static d_gdk_pixbuf_save gdk_pixbuf_save = FuncLoader.LoadFunction<d_gdk_pixbuf_save>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GdkPixbuf), "gdk_pixbuf_save"));
+		static d_gdk_pixbuf_save gdk_pixbuf_save = FuncLoader.LoadFunction<d_gdk_pixbuf_save>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GdkPixbuf), 
+			FuncLoader.IsWindows ? "gdk_pixbuf_save_utf8" : "gdk_pixbuf_save"));
 
 		public unsafe bool Save(string filename, string type) {
 			IntPtr error = IntPtr.Zero;
@@ -312,7 +355,8 @@ namespace Gdk {
 		}
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		delegate bool d_gdk_pixbuf_savev(IntPtr raw, IntPtr filename, IntPtr type, IntPtr[] option_keys, IntPtr[] option_values, out IntPtr error);
-		static d_gdk_pixbuf_savev gdk_pixbuf_savev = FuncLoader.LoadFunction<d_gdk_pixbuf_savev>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GdkPixbuf), "gdk_pixbuf_savev"));
+		static d_gdk_pixbuf_savev gdk_pixbuf_savev = FuncLoader.LoadFunction<d_gdk_pixbuf_savev>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GdkPixbuf), 
+			FuncLoader.IsWindows ? "gdk_pixbuf_savev_utf8" : "gdk_pixbuf_savev"));
 
 		public unsafe bool Savev(string filename, string type, string[] option_keys, string[] option_values) {
 			IntPtr error = IntPtr.Zero;
@@ -332,5 +376,3 @@ namespace Gdk {
 		}
 	}
 }
-
-

--- a/Source/Libs/GdkSharp/PixbufAnimation.cs
+++ b/Source/Libs/GdkSharp/PixbufAnimation.cs
@@ -21,8 +21,23 @@
 namespace Gdk {
 
 	using System;
+	using System.Runtime.InteropServices;
 
 	public partial class PixbufAnimation {
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+		delegate IntPtr d_gdk_pixbuf_animation_new_from_file(IntPtr filename, out IntPtr error);
+		static d_gdk_pixbuf_animation_new_from_file gdk_pixbuf_animation_new_from_file = FuncLoader.LoadFunction<d_gdk_pixbuf_animation_new_from_file>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GdkPixbuf), 
+			FuncLoader.IsWindows ? "gdk_pixbuf_animation_new_from_file_utf8" : "gdk_pixbuf_animation_new_from_file"));
+
+		public PixbufAnimation(string filename) : base(IntPtr.Zero)
+		{
+			IntPtr native_filename = GLib.Marshaller.StringToPtrGStrdup(filename);
+			IntPtr error = IntPtr.Zero;
+			Raw = gdk_pixbuf_animation_new_from_file(native_filename, out error);
+			GLib.Marshaller.Free(native_filename);
+			if (error != IntPtr.Zero) throw new GLib.GException(error);
+		}
 
 		public PixbufAnimation (System.IO.Stream stream) : base (new PixbufLoader (stream).AnimationHandle) {}
 


### PR DESCRIPTION
Some `Pixbuf`, `PixbufAnimation` functions on Windows is exported with "_utf8" suffix.
I hid generated versions, copied and modified code to use "_utf8" on Windows.
Also hid `gdk_pixbuf_new_from_resource*`, `gdk_pixbuf_animation_new_from_resource` because they are using GResources and we already have constructors for .NET resources.

Fixes #230.