### PR TITLE
Fix some mistakes in GtkSourceSearchContext API

### DIFF
--- a/Source/Libs/GtkSourceSharp/GtkSourceSharp.metadata
+++ b/Source/Libs/GtkSourceSharp/GtkSourceSharp.metadata
@@ -14,12 +14,20 @@
   <attr path="/api/namespace/interface[@cname='GtkSourceCompletionProposal']/signal[@name='Changed']" name="name">EmitChanged</attr>
   <attr path="/api/namespace/interface[@cname='GtkSourceUndoManager']/signal[@name='CanRedoChanged']" name="name">EmitCanRedoChanged</attr>
   <attr path="/api/namespace/interface[@cname='GtkSourceUndoManager']/signal[@name='CanUndoChanged']" name="name">EmitCanUndoChanged</attr>
-  <attr path="/api/namespace/object[@cname='GtkSourceSearchContext']/method[@name='Backward']/*/*[@name='match_start']" name="pass_as">ref</attr>
-  <attr path="/api/namespace/object[@cname='GtkSourceSearchContext']/method[@name='Backward']/*/*[@name='match_end']" name="pass_as">ref</attr>
+  <attr path="/api/namespace/object[@cname='GtkSourceSearchContext']/method[@name='Backward']/*/*[@name='match_start']" name="pass_as">out</attr>
+  <attr path="/api/namespace/object[@cname='GtkSourceSearchContext']/method[@name='Backward']/*/*[@name='match_end']" name="pass_as">out</attr>
   <attr path="/api/namespace/object[@cname='GtkSourceSearchContext']/method[@name='Backward']/*/*[@name='has_wrapped_around']" name="pass_as">out</attr>
   <attr path="/api/namespace/object[@cname='GtkSourceSearchContext']/method[@name='Forward']/*/*[@name='match_start']" name="pass_as">ref</attr>
   <attr path="/api/namespace/object[@cname='GtkSourceSearchContext']/method[@name='Forward']/*/*[@name='match_end']" name="pass_as">ref</attr>
+  <attr path="/api/namespace/object[@cname='GtkSourceSearchContext']/method[@name='Forward']/*/*[@name='match_start']" name="pass_as">out</attr>
+  <attr path="/api/namespace/object[@cname='GtkSourceSearchContext']/method[@name='Forward']/*/*[@name='match_end']" name="pass_as">out</attr>
   <attr path="/api/namespace/object[@cname='GtkSourceSearchContext']/method[@name='Forward']/*/*[@name='has_wrapped_around']" name="pass_as">out</attr>
+  <attr path="/api/namespace/object[@cname='GtkSourceSearchContext']/method[@name='ForwardFinish']/*/*[@name='match_start']" name="pass_as">out</attr>
+  <attr path="/api/namespace/object[@cname='GtkSourceSearchContext']/method[@name='ForwardFinish']/*/*[@name='match_end']" name="pass_as">out</attr>
+  <attr path="/api/namespace/object[@cname='GtkSourceSearchContext']/method[@name='ForwardFinish']/*/*[@name='has_wrapped_around']" name="pass_as">out</attr>
+  <attr path="/api/namespace/object[@cname='GtkSourceSearchContext']/method[@name='BackwardFinish']/*/*[@name='match_start']" name="pass_as">out</attr>
+  <attr path="/api/namespace/object[@cname='GtkSourceSearchContext']/method[@name='BackwardFinish']/*/*[@name='match_end']" name="pass_as">out</attr>
+  <attr path="/api/namespace/object[@cname='GtkSourceSearchContext']/method[@name='BackwardFinish']/*/*[@name='has_wrapped_around']" name="pass_as">out</attr>
   <remove-node path="/api/namespace/object[@cname='GtkSourceBuffer']/method[@cname='gtk_source_buffer_can_undo']" />
   <remove-node path="/api/namespace/object[@cname='GtkSourceBuffer']/method[@cname='gtk_source_buffer_can_redo']" />
   <remove-node path="/api/namespace/interface[@cname='GtkSourceStyleSchemeChooser']/property[@cname='style-scheme']" />


### PR DESCRIPTION
The match_start and match_end arguments in the searching functions of GtkSourceSearchContext are out parameters, as per the docs [here](https://developer.gnome.org/gtksourceview/stable/GtkSourceSearchContext.html#gtk-source-search-context-forward-finish).