### PR TITLE
Fix IScrollableImplementor.GetBorder out param

### DIFF
--- a/Source/Libs/GtkSharp/GtkSharp.metadata
+++ b/Source/Libs/GtkSharp/GtkSharp.metadata
@@ -987,7 +987,8 @@
   <attr path="/api/namespace/struct[@cname='GtkTextLogAttrCache']" name="hidden">1</attr>
   <attr path="/api/namespace/struct[@cname='GtkWindowGeometryInfo']" name="hidden">1</attr>
   
-  <attr path="/api/namespace/interface[@cname='GtkScrollable']/method[@name='GetBorder']/*/parameter[@name='border']" name="pass_as">out</attr> 
+  <attr path="/api/namespace/interface[@cname='GtkScrollable']/method[@name='GetBorder']/*/parameter[@name='border']" name="pass_as">out</attr>
+  <attr path="/api/namespace/interface[@cname='GtkScrollable']/virtual_method[@name='GetBorder']/*/parameter[@name='border']" name="pass_as">out</attr>
    
   <move-node path="/api/namespace/class[@cname='GtkBindings_']/method[@name='BindingsActivate']">/api/namespace/class[@cname='GtkGlobal']</move-node>
   <move-node path="/api/namespace/class[@cname='GtkGlobal']/method[@name='PaintArrow']">/api/namespace/object[@cname='GtkStyle']</move-node>


### PR DESCRIPTION
IScrollableImplementor.GetBorder was not generated with out param as in IScrollable.
Supplements #201.

First line changed because of trimmed trailing space.