### PR TITLE
Added Cairo.Path properties

### DIFF
--- a/Source/Libs/CairoSharp/PathData.cs
+++ b/Source/Libs/CairoSharp/PathData.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Cairo
+{
+	[StructLayout(LayoutKind.Explicit)]
+	public struct PathData
+	{
+		[FieldOffset(0)]
+		public PathDataHeader Header;
+		[FieldOffset(0)]
+		public PathDataPoint Point;
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	public struct PathDataHeader
+	{
+		public PathDataType Type;
+		public int Length;
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	public struct PathDataPoint
+	{
+		public double X;
+		public double Y;
+	}
+}

--- a/Source/Libs/CairoSharp/PathDataType.cs
+++ b/Source/Libs/CairoSharp/PathDataType.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Cairo
+{
+	[Serializable]
+	public enum PathDataType
+	{
+		MoveTo,
+		LineTo,
+		CurveTo,
+		ClosePath
+	}
+}


### PR DESCRIPTION
New properties on Path is lazy evaluated. Only reading is supported (you can't create path with custom pathdata).
Partially fixes #247.