### PR TITLE
Fix parameters in Bash script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -97,5 +97,5 @@ fi
 if $SHOW_VERSION; then
     exec mono "$CAKE_EXE" -version
 else
-    exec mono "$CAKE_EXE" $SCRIPT --verbosity=$VERBOSITY --configuration=$CONFIGURATION --target=$TARGET $DRYRUN "${SCRIPT_ARGUMENTS[@]}"
+    exec mono "$CAKE_EXE" $SCRIPT --verbosity=$VERBOSITY --configuration=$CONFIGURATION --BuildTarget=$TARGET $DRYRUN "${SCRIPT_ARGUMENTS[@]}"
 fi


### PR DESCRIPTION
Cake build uses --BuildTarget to specify build target,
as such -t and --target arguments in bash pass incorrect value