### PR TITLE
Fixed Pango.AttrList.Change

### DIFF
--- a/Source/Libs/PangoSharp/AttrList.cs
+++ b/Source/Libs/PangoSharp/AttrList.cs
@@ -27,6 +27,16 @@ namespace Pango {
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		delegate IntPtr d_pango_attribute_copy(IntPtr raw);
 		static d_pango_attribute_copy pango_attribute_copy = FuncLoader.LoadFunction<d_pango_attribute_copy>(FuncLoader.GetProcAddress(GLibrary.Load(Library.Pango), "pango_attribute_copy"));
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+		delegate void d_pango_attr_list_change(IntPtr raw, IntPtr attr);
+		static d_pango_attr_list_change pango_attr_list_change = FuncLoader.LoadFunction<d_pango_attr_list_change>(FuncLoader.GetProcAddress(GLibrary.Load(Library.Pango), "pango_attr_list_change"));
+
+		public void Change (Pango.Attribute attr)
+		{
+			pango_attr_list_change (Handle, pango_attribute_copy (attr.Handle));
+		}
+
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		delegate void d_pango_attr_list_insert(IntPtr raw, IntPtr attr);
 		static d_pango_attr_list_insert pango_attr_list_insert = FuncLoader.LoadFunction<d_pango_attr_list_insert>(FuncLoader.GetProcAddress(GLibrary.Load(Library.Pango), "pango_attr_list_insert"));
@@ -35,6 +45,7 @@ namespace Pango {
 		{
 			pango_attr_list_insert (Handle, pango_attribute_copy (attr.Handle));
 		}
+
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		delegate void d_pango_attr_list_insert_before(IntPtr raw, IntPtr attr);
 		static d_pango_attr_list_insert_before pango_attr_list_insert_before = FuncLoader.LoadFunction<d_pango_attr_list_insert_before>(FuncLoader.GetProcAddress(GLibrary.Load(Library.Pango), "pango_attr_list_insert_before"));
@@ -45,4 +56,3 @@ namespace Pango {
 		}
 	}
 }
-

--- a/Source/Libs/PangoSharp/PangoSharp.metadata
+++ b/Source/Libs/PangoSharp/PangoSharp.metadata
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
+  <attr path="/api/namespace/boxed[@cname='PangoAttrList']/method[@name='Change']" name="hidden">1</attr>
   <attr path="/api/namespace/boxed[@cname='PangoAttrList']/method[@name='Filter']/*/*[@name='func']" name="scope">call</attr>
   <attr path="/api/namespace/boxed[@cname='PangoAttrList']/method[@name='GetIterator']/return-type" name="owned">true</attr>
   <attr path="/api/namespace/boxed[@cname='PangoAttrList']/method[@name='Insert']" name="hidden">1</attr>


### PR DESCRIPTION
`pango_attr_list_change` takes ownership of attribute so we make copy (as in existing `pango_attr_list_insert`).
Fixes bug found in #284.