### PR TITLE
Generalized Idle and Timeout, fixed Timeout.Add

### DIFF
--- a/Source/Libs/GLibSharp/Idle.cs
+++ b/Source/Libs/GLibSharp/Idle.cs
@@ -86,6 +86,11 @@ namespace GLib {
 			return p.ID;
 		}
 
+		public static uint Add (Priority priority, IdleHandler hndlr)
+		{
+			return Add ((int)priority, hndlr);
+		}
+
 		public static uint Add (IdleHandler hndlr)
 		{
 			return Add ((int)Priority.DefaultIdle, hndlr);
@@ -97,5 +102,3 @@ namespace GLib {
 		}
 	}
 }
-
-

--- a/Source/Libs/GLibSharp/Timeout.cs
+++ b/Source/Libs/GLibSharp/Timeout.cs
@@ -68,14 +68,15 @@ namespace GLib {
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		delegate uint d_g_timeout_add_full(int priority, uint interval, TimeoutHandlerInternal d, IntPtr data, DestroyNotify notify);
 		static d_g_timeout_add_full g_timeout_add_full = FuncLoader.LoadFunction<d_g_timeout_add_full>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GLib), "g_timeout_add_full"));
-		public static uint Add (uint interval, TimeoutHandler hndlr)
+
+		public static uint Add (uint interval, TimeoutHandler hndlr, int priority)
 		{
 			TimeoutProxy p = new TimeoutProxy (hndlr);
 			lock (p)
 			{
 				var gch = GCHandle.Alloc(p);
 				var userData = GCHandle.ToIntPtr(gch);
-				p.ID = g_timeout_add_full (0, interval, (TimeoutHandlerInternal) p.proxy_handler, userData, DestroyHelper.NotifyHandler);
+				p.ID = g_timeout_add_full (priority, interval, (TimeoutHandlerInternal) p.proxy_handler, userData, DestroyHelper.NotifyHandler);
 			}
 
 			return p.ID;
@@ -83,32 +84,39 @@ namespace GLib {
 
 		public static uint Add (uint interval, TimeoutHandler hndlr, Priority priority)
 		{
-			TimeoutProxy p = new TimeoutProxy (hndlr);
-			lock (p)
-			{
-				var gch = GCHandle.Alloc(p);
-				var userData = GCHandle.ToIntPtr(gch);
-				p.ID = g_timeout_add_full ((int)priority, interval, (TimeoutHandlerInternal) p.proxy_handler, IntPtr.Zero, null);
-			}
+			return Add (interval, hndlr, (int)priority);
+		}
 
-			return p.ID;
+		public static uint Add (uint interval, TimeoutHandler hndlr)
+		{
+			return Add (interval, hndlr, (int)Priority.Default);
 		}
 
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		delegate uint d_g_timeout_add_seconds_full(int priority, uint interval, TimeoutHandlerInternal d, IntPtr data, DestroyNotify notify);
 		static d_g_timeout_add_seconds_full g_timeout_add_seconds_full = FuncLoader.LoadFunction<d_g_timeout_add_seconds_full>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GLib), "g_timeout_add_seconds_full"));
 
-		public static uint AddSeconds (uint interval, TimeoutHandler hndlr)
+		public static uint AddSeconds (uint interval, TimeoutHandler hndlr, int priority)
 		{
 			TimeoutProxy p = new TimeoutProxy (hndlr);
 			lock (p)
 			{
 				var gch = GCHandle.Alloc(p);
 				var userData = GCHandle.ToIntPtr(gch);
-				p.ID = g_timeout_add_seconds_full (0, interval, (TimeoutHandlerInternal) p.proxy_handler, userData, DestroyHelper.NotifyHandler);
+				p.ID = g_timeout_add_seconds_full (priority, interval, (TimeoutHandlerInternal) p.proxy_handler, userData, DestroyHelper.NotifyHandler);
 			}
 
 			return p.ID;
+		}
+
+		public static uint AddSeconds (uint interval, TimeoutHandler hndlr, Priority priority)
+		{
+			return AddSeconds (interval, hndlr, (int)priority);
+		}
+
+		public static uint AddSeconds (uint interval, TimeoutHandler hndlr)
+		{
+			return AddSeconds (interval, hndlr, (int)Priority.Default);
 		}
 
 		public static void Remove (uint id)
@@ -117,5 +125,3 @@ namespace GLib {
 		}
 	}
 }
-
-


### PR DESCRIPTION
`Idle.Add`, `Idle.AddSeconds`, `Timeout.Add`, `Timeout.AddSeconds` methods overloads are generalized:
* no priority (for default priority)
* enum priority (for standard priorities)
* int priority (for custom priority)
* overloads call main method with int priority

Fixed leak in `Timeout.Add(priority)`: method was not using `userData` and `DestroyHelper.NotifyHandler` as others.