### PR TITLE
Fixed sample for ListStore spinner

### DIFF
--- a/Source/GtkSharp.sln
+++ b/Source/GtkSharp.sln
@@ -1,4 +1,5 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29424.173
 MinimumVisualStudioVersion = 15.0.26124.0

--- a/Source/Samples/Samples.csproj
+++ b/Source/Samples/Samples.csproj
@@ -15,7 +15,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Sections\**\*.cs" Visible="false">
+    <EmbeddedResource Include="Sections\**\*.cs">
       <LogicalName>GtkSharp.Samples.%(Filename).cs</LogicalName>
     </EmbeddedResource>
   </ItemGroup>

--- a/Source/Samples/Sections/Widgets/ListStoreSection.cs
+++ b/Source/Samples/Sections/Widgets/ListStoreSection.cs
@@ -185,7 +185,7 @@ namespace Samples
             else
                 pulse++;
 
-            _model.SetValues(iter, (int)Column.Pulse, pulse);
+            _model.SetValue(iter, (int)Column.Pulse, pulse);
             _model.SetValue(iter, (int)Column.Active, true);
 
             return true;


### PR DESCRIPTION
Spinner was not spinning - should use `SetValue`, not `SetValues`.
Also fixed sln - VS2019 not want to open sln by double click in explorer - added empty line.
Also fixed sample project - VS2019 not showing all sources.