### PR TITLE
Disable loading of additional assemblies in AOT context

### DIFF
--- a/Source/Libs/GLibSharp/GType.cs
+++ b/Source/Libs/GLibSharp/GType.cs
@@ -28,6 +28,7 @@ namespace GLib {
 	using System.Collections.Generic;
 	using System.IO;
 	using System.Reflection;
+	using System.Runtime.CompilerServices;
 	using System.Runtime.InteropServices;
 	using System.Text;
 
@@ -238,7 +239,7 @@ namespace GLib {
 					break;
 			}
 
-			if (result == null) {
+			if (result == null && RuntimeFeature.IsDynamicCodeSupported) {
 				// Because of lazy loading of references, it's possible the type's assembly
 				// needs to be loaded.  We will look for it by name in the references of
 				// the currently loaded assemblies.  Hopefully a recursive traversal is

--- a/Source/Libs/GLibSharp/GType.cs
+++ b/Source/Libs/GLibSharp/GType.cs
@@ -239,7 +239,11 @@ namespace GLib {
 					break;
 			}
 
-			if (result == null && RuntimeFeature.IsDynamicCodeSupported) {
+			if (result == null
+#if NET6_0_OR_GREATER
+				&& RuntimeFeature.IsDynamicCodeSupported
+#endif
+				) {
 				// Because of lazy loading of references, it's possible the type's assembly
 				// needs to be loaded.  We will look for it by name in the references of
 				// the currently loaded assemblies.  Hopefully a recursive traversal is


### PR DESCRIPTION
AOT does not supports `Assembly.Load` and `Assembly.GetReferencedAssemblies()` when running AOT.
I opt-out of code which try to find type. In AOT context this means that you rely on dynamic type loading and you have issues anyway.