### PR TITLE
Update to .NET 6

### DIFF
--- a/Source/Samples/Samples.csproj
+++ b/Source/Samples/Samples.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>..\..\BuildOutput\Samples</OutputPath>
   </PropertyGroup>

--- a/Source/Templates/GtkSharp.Template.CSharp/content/GtkSharp.Application.CSharp/.template.config/template.json
+++ b/Source/Templates/GtkSharp.Template.CSharp/content/GtkSharp.Application.CSharp/.template.config/template.json
@@ -18,8 +18,28 @@
   "symbols": {
     "targetframework": {
       "type": "parameter",
-      "defaultValue": "net5.0",
-      "replaces": "net5.0"
+
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "netcoreapp3.1",
+          "description": "Target netcoreapp3.1",
+          "displayName": ".NET Core 3.1"
+        },
+        {
+          "choice": "net5.0",
+          "description": "Target net5.0",
+          "displayName": ".NET 5.0"
+        },
+        {
+          "choice": "net6.0",
+          "description": "Target net6.0",
+          "displayName": ".NET 6.0"
+        }
+      ],
+      "defaultValue": "net6.0",
+      "replaces": "$(FrameworkParameter)"
     }
   },
   "primaryOutputs": [

--- a/Source/Templates/GtkSharp.Template.CSharp/content/GtkSharp.Application.CSharp/.template.config/template.json
+++ b/Source/Templates/GtkSharp.Template.CSharp/content/GtkSharp.Application.CSharp/.template.config/template.json
@@ -19,24 +19,6 @@
     "targetframework": {
       "type": "parameter",
       "description": "The target framework for the project.",
-      "datatype": "choice",
-      "choices": [
-        {
-          "choice": "netcoreapp3.1",
-          "description": "Target netcoreapp3.1",
-          "displayName": ".NET Core 3.1"
-        },
-        {
-          "choice": "net5.0",
-          "description": "Target net5.0",
-          "displayName": ".NET 5.0"
-        },
-        {
-          "choice": "net6.0",
-          "description": "Target net6.0",
-          "displayName": ".NET 6.0"
-        }
-      ],
       "defaultValue": "net6.0",
       "replaces": "$(FrameworkParameter)"
     }

--- a/Source/Templates/GtkSharp.Template.CSharp/content/GtkSharp.Application.CSharp/.template.config/template.json
+++ b/Source/Templates/GtkSharp.Template.CSharp/content/GtkSharp.Application.CSharp/.template.config/template.json
@@ -18,7 +18,6 @@
   "symbols": {
     "targetframework": {
       "type": "parameter",
-
       "description": "The target framework for the project.",
       "datatype": "choice",
       "choices": [

--- a/Source/Templates/GtkSharp.Template.CSharp/content/GtkSharp.Application.CSharp/GtkNamespace.csproj
+++ b/Source/Templates/GtkSharp.Template.CSharp/content/GtkSharp.Application.CSharp/GtkNamespace.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>$(FrameworkParameter)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Templates/GtkSharp.Template.FSharp/content/GtkSharp.Application.FSharp/.template.config/template.json
+++ b/Source/Templates/GtkSharp.Template.FSharp/content/GtkSharp.Application.FSharp/.template.config/template.json
@@ -18,8 +18,27 @@
   "symbols": {
     "targetframework": {
       "type": "parameter",
-      "defaultValue": "net5.0",
-      "replaces": "net5.0"
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "netcoreapp3.1",
+          "description": "Target netcoreapp3.1",
+          "displayName": ".NET Core 3.1"
+        },
+        {
+          "choice": "net5.0",
+          "description": "Target net5.0",
+          "displayName": ".NET 5.0"
+        },
+        {
+          "choice": "net6.0",
+          "description": "Target net6.0",
+          "displayName": ".NET 6.0"
+        }
+      ],
+      "defaultValue": "net6.0",
+      "replaces": "$(FrameworkParameter)"
     }
   },
   "primaryOutputs": [

--- a/Source/Templates/GtkSharp.Template.FSharp/content/GtkSharp.Application.FSharp/.template.config/template.json
+++ b/Source/Templates/GtkSharp.Template.FSharp/content/GtkSharp.Application.FSharp/.template.config/template.json
@@ -19,24 +19,6 @@
     "targetframework": {
       "type": "parameter",
       "description": "The target framework for the project.",
-      "datatype": "choice",
-      "choices": [
-        {
-          "choice": "netcoreapp3.1",
-          "description": "Target netcoreapp3.1",
-          "displayName": ".NET Core 3.1"
-        },
-        {
-          "choice": "net5.0",
-          "description": "Target net5.0",
-          "displayName": ".NET 5.0"
-        },
-        {
-          "choice": "net6.0",
-          "description": "Target net6.0",
-          "displayName": ".NET 6.0"
-        }
-      ],
       "defaultValue": "net6.0",
       "replaces": "$(FrameworkParameter)"
     }

--- a/Source/Templates/GtkSharp.Template.FSharp/content/GtkSharp.Application.FSharp/GtkNamespace.fsproj
+++ b/Source/Templates/GtkSharp.Template.FSharp/content/GtkSharp.Application.FSharp/GtkNamespace.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>$(FrameworkParameter)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Templates/GtkSharp.Template.VBNet/content/GtkSharp.Application.VBNet/.template.config/template.json
+++ b/Source/Templates/GtkSharp.Template.VBNet/content/GtkSharp.Application.VBNet/.template.config/template.json
@@ -18,8 +18,27 @@
   "symbols": {
     "targetframework": {
       "type": "parameter",
-      "defaultValue": "net5.0",
-      "replaces": "net5.0"
+      "description": "The target framework for the project.",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "netcoreapp3.1",
+          "description": "Target netcoreapp3.1",
+          "displayName": ".NET Core 3.1"
+        },
+        {
+          "choice": "net5.0",
+          "description": "Target net5.0",
+          "displayName": ".NET 5.0"
+        },
+        {
+          "choice": "net6.0",
+          "description": "Target net6.0",
+          "displayName": ".NET 6.0"
+        }
+      ],
+      "defaultValue": "net6.0",
+      "replaces": "$(FrameworkParameter)"
     }
   },
   "primaryOutputs": [

--- a/Source/Templates/GtkSharp.Template.VBNet/content/GtkSharp.Application.VBNet/.template.config/template.json
+++ b/Source/Templates/GtkSharp.Template.VBNet/content/GtkSharp.Application.VBNet/.template.config/template.json
@@ -19,24 +19,6 @@
     "targetframework": {
       "type": "parameter",
       "description": "The target framework for the project.",
-      "datatype": "choice",
-      "choices": [
-        {
-          "choice": "netcoreapp3.1",
-          "description": "Target netcoreapp3.1",
-          "displayName": ".NET Core 3.1"
-        },
-        {
-          "choice": "net5.0",
-          "description": "Target net5.0",
-          "displayName": ".NET 5.0"
-        },
-        {
-          "choice": "net6.0",
-          "description": "Target net6.0",
-          "displayName": ".NET 6.0"
-        }
-      ],
       "defaultValue": "net6.0",
       "replaces": "$(FrameworkParameter)"
     }

--- a/Source/Templates/GtkSharp.Template.VBNet/content/GtkSharp.Application.VBNet/GtkNamespace.vbproj
+++ b/Source/Templates/GtkSharp.Template.VBNet/content/GtkSharp.Application.VBNet/GtkNamespace.vbproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>$(FrameworkParameter)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Tools/GapiCodegen/GapiCodegen.csproj
+++ b/Source/Tools/GapiCodegen/GapiCodegen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputPath>..\..\..\BuildOutput\Tools</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>

--- a/Source/Tools/GapiFixup/GapiFixup.csproj
+++ b/Source/Tools/GapiFixup/GapiFixup.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputPath>..\..\..\BuildOutput\Tools</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,12 @@ pool:
   vmImage: 'ubuntu-latest'
 
 steps:
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core SDK'
+    inputs:
+      version: 6.0.101
+      includePreviewVersions: false
+
   - script: echo "##vso[build.updatebuildnumber]$(version)"
     displayName: 'Set Build Number'
 


### PR DESCRIPTION
I update not only samples, but also codegen tools, because .NET 5 is not LTS and in 4 month would be out.
Added template parameters, and resurrect netcoreapp3.1 support in templates.
Tested with following process
```
dotnet new --install Source/Templates/GtkSharp.Template.CSharp
...
dotnet new gtkapp -t net5.0
```

Closes #306