### PR TITLE
Implement Gdk.Pixbuf.SaveToStream() and SaveToStreamv()

### DIFF
--- a/Source/Libs/GdkSharp/GdkSharp.metadata
+++ b/Source/Libs/GdkSharp/GdkSharp.metadata
@@ -109,6 +109,8 @@
   <attr path="/api/namespace/object[@cname='GdkPixbuf']/method[@name='SaveToBufferv']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GdkPixbuf']/method[@name='SaveToCallback']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GdkPixbuf']/method[@name='SaveToCallbackv']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GdkPixbuf']/method[@name='SaveToStream']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GdkPixbuf']/method[@name='SaveToStreamv']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GdkPixbuf']/method[@name='ScaleSimple']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GdkPixbuf']/method[@name='RotateSimple']/return-type" name="owned">true</attr>
   <attr path="/api/namespace/object[@cname='GdkPixbuf']/property[@name='Pixels']" name="hidden">1</attr>

--- a/Source/Libs/GdkSharp/Pixbuf.cs
+++ b/Source/Libs/GdkSharp/Pixbuf.cs
@@ -374,5 +374,43 @@ namespace Gdk {
 				throw new GLib.GException (error);
 			return saved;
 		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+		delegate bool d_gdk_pixbuf_save_to_stream(IntPtr raw, IntPtr stream, IntPtr type, IntPtr cancellable, out IntPtr error, IntPtr dummy);
+		static d_gdk_pixbuf_save_to_stream gdk_pixbuf_save_to_stream = FuncLoader.LoadFunction<d_gdk_pixbuf_save_to_stream>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GdkPixbuf), "gdk_pixbuf_save_to_stream"));
+
+		public unsafe bool SaveToStream(GLib.OutputStream stream, string type, GLib.Cancellable cancellable)
+		{
+			IntPtr error = IntPtr.Zero;
+			IntPtr native_type = GLib.Marshaller.StringToPtrGStrdup(type);
+			bool ret = gdk_pixbuf_save_to_stream(Handle, stream == null ? IntPtr.Zero : stream.Handle, native_type, cancellable == null ? IntPtr.Zero : cancellable.Handle, out error, IntPtr.Zero);
+			GLib.Marshaller.Free(native_type);
+
+			if (error != IntPtr.Zero)
+				throw new GLib.GException(error);
+
+			return ret;
+		}
+
+		[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
+		delegate bool d_gdk_pixbuf_save_to_streamv(IntPtr raw, IntPtr stream, IntPtr type, IntPtr[] option_keys, IntPtr[] option_values, IntPtr cancellable, out IntPtr error);
+		static d_gdk_pixbuf_save_to_streamv gdk_pixbuf_save_to_streamv = FuncLoader.LoadFunction<d_gdk_pixbuf_save_to_streamv>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GdkPixbuf), "gdk_pixbuf_save_to_streamv"));
+
+		public unsafe bool SaveToStreamv(GLib.OutputStream stream, string type, string[] option_keys, string[] option_values, GLib.Cancellable cancellable)
+		{
+			IntPtr error = IntPtr.Zero;
+			IntPtr native_type = GLib.Marshaller.StringToPtrGStrdup(type);
+			IntPtr[] native_option_keys = NullTerm (option_keys);
+			IntPtr[] native_option_values = NullTerm (option_values);
+			bool ret = gdk_pixbuf_save_to_streamv(Handle, stream == null ? IntPtr.Zero : stream.Handle, native_type, native_option_keys, native_option_values, cancellable == null ? IntPtr.Zero : cancellable.Handle, out error);
+			GLib.Marshaller.Free (native_type);
+			ReleaseArray (native_option_keys);
+			ReleaseArray (native_option_values);
+
+			if (error != IntPtr.Zero)
+                throw new GLib.GException (error);
+
+			return ret;
+		}
 	}
 }


### PR DESCRIPTION
This matches the other saving-related methods for Gdk.Pixbuf, and enables saving a pixbuf to a `GFile` stream

- `gdk_pixbuf_save_to_stream` was skipped for the auto-generated bindings (with the warning "Ellipsis parameter: hide and bind manually")

- `gdk_pixbuf_save_to_streamv` was in the generated bindings, but incorrect: the `option_keys` and `option_values` arguments had type `string` rather than `string[]`