### PR TITLE
Fix "Could not locate nuget.exe"

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -2,6 +2,7 @@
 #load CakeScripts\Settings.cake
 #addin "Cake.FileHelpers&version=5.0.0"
 #addin "Cake.Incubator&version=7.0.0"
+#tool nuget:?package=NuGet.CommandLine&version=6.0.0
 
 // VARS
 


### PR DESCRIPTION
Updated to last code and got (Windows 10):

```
========================================
PackageTemplates
========================================
An error occurred when executing task 'PackageTemplates'.
Error: One or more errors occurred. (Could not locate nuget.exe.)
        Could not locate nuget.exe.
```

Fix from https://stackoverflow.com/questions/67704884/cake-nugetrestore-could-not-locate-nuget-exe
