### PR TITLE
Fix bunch of warnings from code analysis

### DIFF
--- a/Source/Tools/GapiCodegen/CallbackGen.cs
+++ b/Source/Tools/GapiCodegen/CallbackGen.cs
@@ -246,7 +246,7 @@ namespace GtkSharp.Generation {
 			sw.WriteLine ("\t\t\t\tGLib.ExceptionManager.RaiseUnhandledException (e, " + (fatal ? "true" : "false") + ");");
 			if (fatal) {
 				sw.WriteLine ("\t\t\t\t// NOTREACHED: Above call does not return.");
-				sw.WriteLine ("\t\t\t\tthrow e;");
+				sw.WriteLine ("\t\t\t\tthrow;");
 			} else if (retval.MarshalType == "bool") {
 				sw.WriteLine ("\t\t\t\treturn false;");
 			}

--- a/Source/Tools/GapiCodegen/VirtualMethod.cs
+++ b/Source/Tools/GapiCodegen/VirtualMethod.cs
@@ -117,7 +117,7 @@ namespace GtkSharp.Generation {
 			sw.WriteLine ("\t\t\t\tGLib.ExceptionManager.RaiseUnhandledException (e, " + (fatal ? "true" : "false") + ");");
 			if (fatal) {
 				sw.WriteLine ("\t\t\t\t// NOTREACHED: above call does not return.");
-				sw.WriteLine ("\t\t\t\tthrow e;");
+				sw.WriteLine ("\t\t\t\tthrow;");
 			}
 
 			if (call.HasDisposeParam) {


### PR DESCRIPTION
Warnings produced complain that re-throw did not properly capture stack trace.
Given that these rethrow just to please compiler, I think it is better fix that.