### PR TITLE
Fix loading of resources if jit inlines method

### DIFF
--- a/Source/Libs/GdkSharp/Pixbuf.cs
+++ b/Source/Libs/GdkSharp/Pixbuf.cs
@@ -35,6 +35,7 @@
 namespace Gdk {
 
 	using System;
+	using System.Runtime.CompilerServices;
 	using System.Runtime.InteropServices;
 
 	public partial class Pixbuf {
@@ -94,14 +95,16 @@ namespace Gdk {
 				Raw = pl.PixbufHandle;
 			}
 		}
-		
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		public Pixbuf (System.Reflection.Assembly assembly, string resource) : base (IntPtr.Zero)
 		{
 			using (PixbufLoader pl = new PixbufLoader (assembly == null ? System.Reflection.Assembly.GetCallingAssembly () : assembly, resource)) {
 				Raw = pl.PixbufHandle;
 			}
 		}
-				
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		public Pixbuf (System.Reflection.Assembly assembly, string resource, int width, int height) : base (IntPtr.Zero)
 		{
 			using (PixbufLoader pl = new PixbufLoader (assembly == null ? System.Reflection.Assembly.GetCallingAssembly () : assembly, resource, width, height)) {
@@ -123,6 +126,7 @@ namespace Gdk {
 			}
 		}
 
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		static public Pixbuf LoadFromResource (string resource)
 		{
 			return new Pixbuf (System.Reflection.Assembly.GetCallingAssembly (), resource);

--- a/Source/Libs/GdkSharp/PixbufAnimation.cs
+++ b/Source/Libs/GdkSharp/PixbufAnimation.cs
@@ -21,6 +21,7 @@
 namespace Gdk {
 
 	using System;
+	using System.Runtime.CompilerServices;
 	using System.Runtime.InteropServices;
 
 	public partial class PixbufAnimation {
@@ -46,6 +47,7 @@ namespace Gdk {
 			}
 		}
 
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		public PixbufAnimation (System.Reflection.Assembly assembly, string resource) : base (IntPtr.Zero)
 		{
 			if (assembly == null)
@@ -56,6 +58,7 @@ namespace Gdk {
 			}
 		}
 
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		static public PixbufAnimation LoadFromResource (string resource)
 		{
 			return new PixbufAnimation (System.Reflection.Assembly.GetCallingAssembly (), resource);

--- a/Source/Libs/GdkSharp/PixbufLoader.cs
+++ b/Source/Libs/GdkSharp/PixbufLoader.cs
@@ -24,6 +24,7 @@
 namespace Gdk {
 
 	using System;
+	using System.Runtime.CompilerServices;
 	using System.Runtime.InteropServices;
 
 	public partial class PixbufLoader {
@@ -96,6 +97,7 @@ namespace Gdk {
 			InitFromStream(stream);
 		}
 
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		public PixbufLoader (System.Reflection.Assembly assembly, string resource) : this ()
 		{
 			InitFromAssemblyResource(assembly == null ? System.Reflection.Assembly.GetCallingAssembly () : assembly, resource);
@@ -116,7 +118,8 @@ namespace Gdk {
 				Close ();
 			}
 		}
-		
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		public PixbufLoader (System.Reflection.Assembly assembly, string resource, int width, int height) : this ()
 		{
 			SetSize(width, height);
@@ -135,8 +138,7 @@ namespace Gdk {
 			} finally {
 				Close ();
 			}
-		}
-		
+		}		
 		
 		public PixbufLoader (byte[] buffer, int width, int height) : this()
 		{
@@ -144,11 +146,10 @@ namespace Gdk {
 			InitFromBuffer(buffer);
 		}
 
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		static public PixbufLoader LoadFromResource (string resource)
 		{
 			return new PixbufLoader (System.Reflection.Assembly.GetCallingAssembly (), resource);
 		}
 	}
 }
-
-

--- a/Source/Libs/GtkSharp/Builder.cs
+++ b/Source/Libs/GtkSharp/Builder.cs
@@ -28,6 +28,7 @@ namespace Gtk {
 	using System;
 	using System.IO;
 	using System.Reflection;
+	using System.Runtime.CompilerServices;
 	using System.Runtime.InteropServices;
 	using System.Text;
 
@@ -174,16 +175,19 @@ namespace Gtk {
 			AddFromStream (s);
 			TranslationDomain = translation_domain;
 		}
-		
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		public Builder (string resource_name) : this (Assembly.GetCallingAssembly (), resource_name, null)
 		{
 		}
-		
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		public Builder (string resource_name, string translation_domain)
 			: this (Assembly.GetCallingAssembly (), resource_name, translation_domain)
 		{
 		}
-		
+
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		public Builder (Assembly assembly, string resource_name, string translation_domain) : this ()
 		{
 			if (GetType() != typeof (Builder))

--- a/Source/Libs/GtkSharp/CssProvider.cs
+++ b/Source/Libs/GtkSharp/CssProvider.cs
@@ -3,11 +3,14 @@ namespace Gtk
 	using System;
 	using System.IO;
 	using System.Reflection;
+	using System.Runtime.CompilerServices;
 
 	public partial class CssProvider
 	{
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		public bool LoadFromResource(string resource) => LoadFromResource(Assembly.GetCallingAssembly(), resource);
 
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		public bool LoadFromResource(Assembly assembly, string resource)
 		{
 			if (assembly == null)

--- a/Source/Libs/GtkSharp/Image.cs
+++ b/Source/Libs/GtkSharp/Image.cs
@@ -23,6 +23,7 @@ namespace Gtk {
 
 	using System;
 	using System.Collections.Generic;
+	using System.Runtime.CompilerServices;
 	using System.Runtime.InteropServices;
 
 	public partial class Image {
@@ -83,6 +84,7 @@ namespace Gtk {
 			LoadFromStream (stream);
 		}
 
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		public Image (System.Reflection.Assembly assembly, string resource) : this ()
 		{
 			if (assembly == null)
@@ -95,6 +97,7 @@ namespace Gtk {
 			LoadFromStream (s);
 		}
 
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		static public Image LoadFromResource (string resource)
 		{
 			return new Image (System.Reflection.Assembly.GetCallingAssembly (), resource);

--- a/Source/Libs/GtkSharp/UIManager.cs
+++ b/Source/Libs/GtkSharp/UIManager.cs
@@ -21,10 +21,12 @@
 namespace Gtk {
 
 	using System;
+	using System.Runtime.CompilerServices;
 	using System.Runtime.InteropServices;
 
 	public partial class UIManager {
 
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		public uint AddUiFromResource (string resource)
 		{
 			if (resource == null)


### PR DESCRIPTION
Added no inlining attribute for methods with Assembly.GetCallingAssembly() so caller assembly is correct if jit want to inline.
See https://github.com/picoe/Eto/pull/2049.