### PR TITLE
Unhide EventHelper.HandlerSet method

### DIFF
--- a/Source/Libs/GdkSharp/GdkSharp.metadata
+++ b/Source/Libs/GdkSharp/GdkSharp.metadata
@@ -16,7 +16,6 @@
   <attr path="/api/namespace/class[@cname='GdkCairo_']/method[@name='GetClipRectangle']/parameters/parameter[@name='rect']" name="pass_as">out</attr>
   <attr path="/api/namespace/class[@cname='GdkDrag_']/method[@name='Begin']" name="hidden">1</attr>
   <attr path="/api/namespace/class[@cname='GdkDrag_']/method[@name='FindWindowForScreen']/*/*[@name='dest_window']" name="pass_as">out</attr>
-  <attr path="/api/namespace/class[@cname='GdkEvent_']/method[@name='HandlerSet']" name="hidden">1</attr>
   <attr path="/api/namespace/class[@cname='GdkEvent_']" name="name">EventHelper</attr>
   <attr path="/api/namespace/class[@cname='GdkKeyval_']/method[@name='Name']/return-type" name="type">const-gchar*</attr>
   <attr path="/api/namespace/class[@cname='GdkGlobal']/method[@name='AddOptionEntriesLibgtkOnly']" name="hidden">1</attr>


### PR DESCRIPTION
I need `gdk_event_handler_set` to create a global event handler as described here: https://stackoverflow.com/questions/64957969/can-i-set-up-a-global-gtk-accelerator-for-mouse-buttons?rq=1

See https://docs.gtk.org/gdk3/type_func.Event.handler_set.html
