### PR TITLE
Fix loading native libraries on macOS (arm64) using homebrew installed gtk+3

### DIFF
--- a/Source/Libs/Shared/GLibrary.cs
+++ b/Source/Libs/Shared/GLibrary.cs
@@ -73,6 +73,9 @@ class GLibrary
 
 			if (ret == IntPtr.Zero) {
 				ret = FuncLoader.LoadLibrary("/usr/local/lib/" + _libraryDefinitions[library][2]);
+				if (ret == IntPtr.Zero) {
+					ret = FuncLoader.LoadLibrary("/opt/homebrew/lib/" + _libraryDefinitions[library][2]);
+				}
 			}
 		} else
 			ret = FuncLoader.LoadLibrary(_libraryDefinitions[library][1]);


### PR DESCRIPTION
brew used to install libraries under `/usr/local/` and GtkSharp still
expect this location.

https://github.com/GtkSharp/GtkSharp/blob/7995f132e19e18b8dae94359246540f059e53a86/Source/Libs/Shared/GLibrary.cs#L55

This fix will lookup the new library location `/opt/homebrew/lib/` if the
default ones (OS) or the `/usr/local/lib` could not load the libraries.

Reference: https://github.com/unoplatform/uno/issues/8296#issuecomment-1100435406

Fixes https://github.com/GtkSharp/GtkSharp/issues/249