### PR TITLE
GtkSharp-api.xml: fix TouchEvent event-type

### DIFF
--- a/Source/Libs/GtkSharp/GtkSharp-api.xml
+++ b/Source/Libs/GtkSharp/GtkSharp-api.xml
@@ -28475,7 +28475,7 @@
       <signal name="TouchEvent" cname="touch-event" when="LAST" field_name="touch_event">
         <return-type type="gboolean" />
         <parameters>
-          <parameter type="GdkEventTouch*" name="event" />
+          <parameter type="GdkEvent*" name="event" />
         </parameters>
       </signal>
       <signal name="ScrollEvent" cname="scroll-event" when="LAST" field_name="scroll_event">


### PR DESCRIPTION
fix https://github.com/GtkSharp/GtkSharp/issues/299

https://docs.gtk.org/gtk3/signal.Widget.touch-event.html

defines: 
``
gboolean
touch_event (
  GtkWidget* self,
  GdkEvent* object,
  gpointer user_data
)
``

definition in 
**GtkSharp-api.xml**

is **wrong**:

``
      <signal name="TouchEvent" cname="touch-event" when="LAST" field_name="touch_event">
        <return-type type="gboolean" />
        <parameters>
          <parameter type="GdkEventTouch*" name="event" />
        </parameters>
      </signal>
``


definition in
/usr/share/gir-1.0/Gtk-3.0.gir

``
      <glib:signal name="touch-event" when="last">
        <return-value transfer-ownership="none">
          <type name="gboolean" c:type="gboolean"/>
        </return-value>
        <parameters>
          <parameter name="object" transfer-ownership="none">
            <type name="Gdk.Event"/>
          </parameter>
        </parameters>
      </glib:signal>
``

re-generating 
**GtkSharp-api.xml**

with bindinator 
``
/usr/bin/xsltproc -o GtkSharp-api.xml /usr/local/lib/bindinator/gir2gapi.xslt /usr/share/gir-1.0/Gtk-3.0.gir
``

gives us:

``
      <signal name="TouchEvent" cname="touch-event" when="last" field_name="touch_event">
        <return-type type="gboolean"/>
        <parameters>
          <parameter name="_object" type="GdkEvent*"/>
        </parameters>
      </signal>
``

