### PR TITLE
Fixed g_content_type_guess array parameter

### DIFF
--- a/Source/Libs/GioSharp/GioSharp.metadata
+++ b/Source/Libs/GioSharp/GioSharp.metadata
@@ -14,6 +14,8 @@
   <attr path="/api/namespace/class[@cname='GContent_']/method[@name='TypeGetDescription']" name="name">GetDescription</attr>
   <attr path="/api/namespace/class[@cname='GContent_']/method[@name='TypeGetIcon']" name="name">GetIcon</attr>
   <attr path="/api/namespace/class[@cname='GContent_']/method[@name='TypeGetMimeType']" name="name">GetMimeType</attr>
+  <attr path="/api/namespace/class[@cname='GContent_']/method[@name='TypeGuess']/parameters/parameter[@name='data']" name="array">1</attr>
+  <attr path="/api/namespace/class[@cname='GContent_']/method[@name='TypeGuess']/parameters/parameter[@name='data_size']" name="name">n_data</attr>
   <attr path="/api/namespace/class[@cname='GContent_']/method[@name='TypeGuess']" name="name">Guess</attr>
   <attr path="/api/namespace/class[@cname='GContent_']/method[@name='TypeGuessForTree']" name="name">GuessForTree</attr>
   <attr path="/api/namespace/class[@cname='GContent_']/method[@name='TypeIsA']" name="name">IsA</attr>


### PR DESCRIPTION
Fixes #359.
`data_size` renamed to detect it as count parameter for `data` array.