### PR TITLE
Fixed NodeView.GetCellArea

### DIFF
--- a/Source/Libs/GtkSharp/NodeView.cs
+++ b/Source/Libs/GtkSharp/NodeView.cs
@@ -83,7 +83,7 @@ namespace Gtk {
 		}
 		
 		public Gdk.Rectangle GetCellArea (ITreeNode node, Gtk.TreeViewColumn column) {
-			return GetBackgroundArea (store.GetPath (node), column);
+			return GetCellArea (store.GetPath (node), column);
 		}
 		
 		public ITreeNode GetNodeAtPos (int x, int y) {


### PR DESCRIPTION
Looks like copy-paste error from above GetBackgroundArea method