### PR TITLE
Fixed assembly search for requested type

### DIFF
--- a/Source/Libs/GLibSharp/GType.cs
+++ b/Source/Libs/GLibSharp/GType.cs
@@ -251,15 +251,15 @@ namespace GLib {
 				// in a patch from bug #400595, and a desire to keep memory usage low
 				// by avoiding a complete loading of all dependent assemblies.
 				string ns = type_name.Substring (0, type_name.LastIndexOf ('.'));
-				string asm_name = ns.ToLower ().Replace ('.', '-') + "-sharp";
+				string asm_name = ns.Replace (".", "") + "Sharp";
 				foreach (Assembly asm in assemblies) {
 					foreach (AssemblyName ref_name in asm.GetReferencedAssemblies ()) {
 						if (ref_name.Name != asm_name)
 							continue;
 						try {
-							string asm_dir = Path.GetDirectoryName (asm.Location);
+							string asm_dir = Path.GetDirectoryName (asm.Location); // will be null or empty for single file publish
 							Assembly ref_asm;
-							if (File.Exists (Path.Combine (asm_dir, ref_name.Name + ".dll")))
+							if (!string.IsNullOrEmpty (asm_dir) && File.Exists (Path.Combine (asm_dir, ref_name.Name + ".dll")))
 								ref_asm = Assembly.LoadFrom (Path.Combine (asm_dir, ref_name.Name + ".dll"));
 							else
 								ref_asm = Assembly.Load (ref_name);


### PR DESCRIPTION
Old gtksharp2 name "pango-sharp" to new gtksharp3 name "PangoSharp".
Also added check to empty assembly location that will be in single file published projects.