### PR TITLE
Add gtk composite template support v2

### DIFF
--- a/Source/Libs/GtkSharp/Bin.cs
+++ b/Source/Libs/GtkSharp/Bin.cs
@@ -24,9 +24,6 @@ namespace Gtk {
 	using System.Runtime.InteropServices;
 
 	public partial class Bin {
-
-		protected Bin() : base() { }
-
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		delegate IntPtr d_gtk_bin_get_child(IntPtr raw);
 		static d_gtk_bin_get_child gtk_bin_get_child = FuncLoader.LoadFunction<d_gtk_bin_get_child>(FuncLoader.GetProcAddress(GLibrary.Load(Library.Gtk), "gtk_bin_get_child"));

--- a/Source/Libs/GtkSharp/Bin.cs
+++ b/Source/Libs/GtkSharp/Bin.cs
@@ -24,6 +24,9 @@ namespace Gtk {
 	using System.Runtime.InteropServices;
 
 	public partial class Bin {
+
+		protected Bin() : base() { }
+
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		delegate IntPtr d_gtk_bin_get_child(IntPtr raw);
 		static d_gtk_bin_get_child gtk_bin_get_child = FuncLoader.LoadFunction<d_gtk_bin_get_child>(FuncLoader.GetProcAddress(GLibrary.Load(Library.Gtk), "gtk_bin_get_child"));

--- a/Source/Libs/GtkSharp/Box.cs
+++ b/Source/Libs/GtkSharp/Box.cs
@@ -1,0 +1,30 @@
+// Gtk.Box.cs - Gtk Box class customizations
+//
+// Author: Marcel Tiede
+//
+// Copyright (C) 2019 Marcel Tiede
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of version 2 of the Lesser GNU General 
+// Public License as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this program; if not, write to the
+// Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+// Boston, MA 02111-1307, USA.
+
+namespace Gtk {
+
+	using System;
+	using System.Runtime.InteropServices;
+
+	public partial class Box {
+
+		protected Box() : base() { }
+	}
+}

--- a/Source/Libs/GtkSharp/Builder.cs
+++ b/Source/Libs/GtkSharp/Builder.cs
@@ -33,90 +33,6 @@ namespace Gtk {
 	using System.Text;
 
 	public partial class Builder {
-
-		[System.Serializable]
-		public class HandlerNotFoundException : SystemException
-		{
-			string handler_name;
-			string signal_name;
-			System.Reflection.EventInfo evnt;
-			Type delegate_type;
-		
-			public HandlerNotFoundException (string handler_name, string signal_name,
-							 System.Reflection.EventInfo evnt, Type delegate_type)
-				: this (handler_name, signal_name, evnt, delegate_type, null)
-			{
-			}
-		
-			public HandlerNotFoundException (string handler_name, string signal_name,
-							 System.Reflection.EventInfo evnt, Type delegate_type, Exception inner)
-				: base ("No handler " + handler_name + " found for signal " + signal_name,
-					inner)
-			{
-				this.handler_name = handler_name;
-				this.signal_name = signal_name;
-				this.evnt = evnt;
-				this.delegate_type = delegate_type;
-			}
-		
-			public HandlerNotFoundException (string message, string handler_name, string signal_name,
-							 System.Reflection.EventInfo evnt, Type delegate_type)
-				: base ((message != null) ? message : "No handler " + handler_name + " found for signal " + signal_name,
-					null)
-			{
-				this.handler_name = handler_name;
-				this.signal_name = signal_name;
-				this.evnt = evnt;
-				this.delegate_type = delegate_type;
-			}
-		
-			protected HandlerNotFoundException (System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
-				: base (info, context)
-			{
-				handler_name = info.GetString ("HandlerName");
-				signal_name = info.GetString ("SignalName");
-				evnt = info.GetValue ("Event", typeof (System.Reflection.EventInfo)) as System.Reflection.EventInfo;
-				delegate_type = info.GetValue ("DelegateType", typeof (Type)) as Type;
-			}
-		
-			public string HandlerName
-			{
-				get {
-					return handler_name;
-				}
-			}
-		
-			public string SignalName
-			{
-				get {
-					return signal_name;
-				}
-			}
-		
-			public System.Reflection.EventInfo Event
-			{
-				get {
-					return evnt;
-				}
-			}
-		
-			public Type DelegateType
-			{
-				get {
-					return delegate_type;
-				}
-			}
-		
-			public override void GetObjectData (System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
-			{
-				base.GetObjectData (info, context);
-				info.AddValue ("HandlerName", handler_name);
-				info.AddValue ("SignalName", signal_name);
-				info.AddValue ("Event", evnt);
-				info.AddValue ("DelegateType", delegate_type);
-			}
-		}
-		
 		
 		[AttributeUsage (AttributeTargets.Field)]
 		public class ObjectAttribute : Attribute
@@ -207,170 +123,24 @@ namespace Gtk {
 		
 		public void Autoconnect (object handler)
 		{
-			BindFields (handler);
-			(new SignalConnector (this, handler)).ConnectSignals ();
+			Autoconnect (handler, false);
 		}
-		
+
+		public void Autoconnect (object handler, bool throwOnUnknownObject)
+		{
+			BindFields (handler, handler.GetType (), throwOnUnknownObject);
+			new SignalConnector (handler).ConnectSignals (this);
+		}
+
 		public void Autoconnect (Type handler_class)
 		{
-			BindFields (handler_class);
-			(new SignalConnector (this, handler_class)).ConnectSignals ();
+			Autoconnect (handler_class, false);
 		}
 		
-		class SignalConnector
+		public void Autoconnect (Type handler_class, bool throwOnUnknownObject)
 		{
-			Builder builder;
-			Type handler_type;
-			object handler;
-		
-			public SignalConnector (Builder builder, object handler)
-			{
-				this.builder = builder;
-				this.handler = handler;
-				handler_type = handler.GetType ();
-			}
-		
-			public SignalConnector (Builder builder, Type handler_type)
-			{
-				this.builder = builder;
-				this.handler = null;
-				this.handler_type = handler_type;		
-			}
-		
-		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-		delegate void d_gtk_builder_connect_signals_full(IntPtr raw, GtkSharp.BuilderConnectFuncNative func, IntPtr user_data);
-		static d_gtk_builder_connect_signals_full gtk_builder_connect_signals_full = FuncLoader.LoadFunction<d_gtk_builder_connect_signals_full>(FuncLoader.GetProcAddress(GLibrary.Load(Library.Gtk), "gtk_builder_connect_signals_full"));
-		
-			public void ConnectSignals() {
-				GtkSharp.BuilderConnectFuncWrapper func_wrapper = new GtkSharp.BuilderConnectFuncWrapper (new BuilderConnectFunc (ConnectFunc));
-				gtk_builder_connect_signals_full(builder.Handle, func_wrapper.NativeDelegate, IntPtr.Zero);
-			}
-		
-			public void ConnectFunc (Builder builder, GLib.Object objekt, string signal_name, string handler_name, GLib.Object connect_object, GLib.ConnectFlags flags)
-			{
-				/* search for the event to connect */
-				System.Reflection.MemberInfo[] evnts = objekt.GetType ().
-					FindMembers (System.Reflection.MemberTypes.Event,
-					     System.Reflection.BindingFlags.Instance
-					     | System.Reflection.BindingFlags.Static
-					     | System.Reflection.BindingFlags.Public
-					     | System.Reflection.BindingFlags.NonPublic,
-					     new System.Reflection.MemberFilter (SignalFilter), signal_name);
-				foreach (System.Reflection.EventInfo ei in evnts) {
-					bool connected = false;
-					System.Reflection.MethodInfo add = ei.GetAddMethod ();
-					System.Reflection.ParameterInfo[] addpi = add.GetParameters ();
-					if (addpi.Length == 1) { /* this should be always true, unless there's something broken */
-						Type delegate_type = addpi[0].ParameterType;
-		
-						/* look for an instance method */
-						if (connect_object != null || handler != null)
-							try {
-								Delegate d = Delegate.CreateDelegate (delegate_type, connect_object != null ? connect_object : handler, handler_name);
-								add.Invoke (objekt, new object[] { d } );
-								connected = true;
-							} catch (ArgumentException) { /* ignore if there is not such instance method */
-							}
-		
-						/* look for a static method if no instance method has been found */
-						if (!connected && handler_type != null)
-							try  {
-								Delegate d = Delegate.CreateDelegate (delegate_type, handler_type, handler_name);
-								add.Invoke (objekt, new object[] { d } );
-								connected = true;
-							} catch (ArgumentException) { /* ignore if there is not such static method */
-							}
-		
-						if (!connected) {
-							string msg = ExplainError (ei.Name, delegate_type, handler_type, handler_name);
-							throw new HandlerNotFoundException (msg, handler_name, signal_name, ei, delegate_type);
-						}
-					}
-				}
-			}
-		
-			static bool SignalFilter (System.Reflection.MemberInfo m, object filterCriteria)
-			{
-				string signame = (filterCriteria as string);
-				object[] attrs = m.GetCustomAttributes (typeof (GLib.SignalAttribute), false);
-				if (attrs.Length > 0)
-				{
-					foreach (GLib.SignalAttribute a in attrs)
-					{
-						if (signame == a.CName)
-						{
-							return true;
-						}
-					}
-					return false;
-				}
-				else
-				{
-					/* this tries to match the names when no attibutes are present.
-					   It is only a fallback. */
-					signame = signame.ToLower ().Replace ("_", "");
-					string evname = m.Name.ToLower ();
-					return signame == evname;
-				}
-			}
-		
-			static string GetSignature (System.Reflection.MethodInfo method)
-			{
-				if (method == null)
-					return null;
-		
-				System.Reflection.ParameterInfo [] parameters = method.GetParameters ();
-				System.Text.StringBuilder sb = new System.Text.StringBuilder ();
-				sb.Append ('(');
-				foreach (System.Reflection.ParameterInfo info in parameters) {
-					sb.Append (info.ParameterType.ToString ());
-					sb.Append (',');
-				}
-				if (sb.Length != 0)
-					sb.Length--;
-		
-				sb.Append (')');
-				return sb.ToString ();
-			}
-		
-			static string GetSignature (Type delegate_type)
-			{
-				System.Reflection.MethodInfo method = delegate_type.GetMethod ("Invoke");
-				return GetSignature (method);
-			}
-		
-			const System.Reflection.BindingFlags flags = System.Reflection.BindingFlags.NonPublic |
-							System.Reflection.BindingFlags.Public |
-							System.Reflection.BindingFlags.Static |
-							System.Reflection.BindingFlags.Instance;
-			static string GetSignature (Type klass, string method_name)
-			{
-				try {
-					System.Reflection.MethodInfo method = klass.GetMethod (method_name, flags);
-					return GetSignature (method);
-				} catch {
-					// May be more than one method with that name and none matches
-					return null;
-				}
-			}
-		
-		
-			static string ExplainError (string event_name, Type deleg, Type klass, string method)
-			{
-				if (deleg == null || klass == null || method == null)
-					return null;
-		
-				System.Text.StringBuilder sb = new System.Text.StringBuilder ();
-				string expected = GetSignature (deleg);
-				string actual = GetSignature (klass, method);
-				if (actual == null)
-					return null;
-					sb.AppendFormat ("The handler for the event {0} should take '{1}', " +
-						"but the signature of the provided handler ('{2}') is '{3}'\n",
-						event_name, expected, method, actual);
-				return sb.ToString ();
-			}
-		
+			BindFields (null, handler_class, throwOnUnknownObject);
+			new SignalConnector (handler_class).ConnectSignals (this);
 		}
 		
 		void AddFromStream (Stream stream)
@@ -390,17 +160,7 @@ namespace Gtk {
 			AddFromString (text);
 		}
 		
-		void BindFields (object target)
-		{
-			BindFields (target, target.GetType ());
-		}
-		
-		void BindFields (Type type)
-		{
-			BindFields (null, type);
-		}
-		
-		void BindFields (object target, Type type)
+		void BindFields (object target, Type type, bool throwOnUnknownObject)
 		{
 			System.Reflection.BindingFlags flags = System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.DeclaredOnly;
 			if (target != null)
@@ -421,11 +181,8 @@ namespace Gtk {
 					// The widget to field binding must be 1:1, so only check
 					// the first attribute.
 					ObjectAttribute attr = (ObjectAttribute) attrs[0];
-					GLib.Object gobject;
-					if (attr.Specified)
-						gobject = GetObject (attr.Name);
-					else
-						gobject = GetObject (field.Name);
+					string name = attr.Specified ? attr.Name : field.Name;
+					GLib.Object gobject = GetObject (name);
 		
 					if (gobject != null)
 						try {
@@ -434,6 +191,8 @@ namespace Gtk {
 							Console.WriteLine ("Unable to set value for field " + field.Name);
 							throw e;
 						}
+					else if (throwOnUnknownObject)
+						throw new Exception ("Unknown object '" + name + "' to connect in type '" + type + "'");
 				}
 				type = type.BaseType;
 			}
@@ -441,4 +200,3 @@ namespace Gtk {
 		}
 	}
 }
-

--- a/Source/Libs/GtkSharp/ChildAttribute.cs
+++ b/Source/Libs/GtkSharp/ChildAttribute.cs
@@ -1,0 +1,38 @@
+// ChildAttribute.cs - Child attribute
+//
+// Author:
+//	 Marcel Tiede
+//
+// Copyright (c) 2019 Marcel Tiede
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of version 2 of the Lesser GNU General 
+// Public License as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this program; if not, write to the
+// Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+// Boston, MA 02111-1307, USA.
+
+namespace Gtk
+{
+    using System;
+    
+    [AttributeUsage(AttributeTargets.Field)]
+    public class ChildAttribute : Attribute
+    {
+        public string Name { get; }
+        public bool Internal { get; }
+
+        public ChildAttribute(string name = null, bool @internal = false)
+        {
+            this.Name = name;
+            this.Internal = @internal;
+        }
+    }
+}

--- a/Source/Libs/GtkSharp/Container.cs
+++ b/Source/Libs/GtkSharp/Container.cs
@@ -51,8 +51,6 @@ namespace Gtk
             public uint param_id;
         };
 
-        protected Container() : base() { }
-
         public GLib.Value ChildGetProperty(Gtk.Widget child, string property_name)
         {
             IntPtr native_property_name = GLib.Marshaller.StringToPtrGStrdup(property_name);

--- a/Source/Libs/GtkSharp/Container.cs
+++ b/Source/Libs/GtkSharp/Container.cs
@@ -51,6 +51,8 @@ namespace Gtk
             public uint param_id;
         };
 
+        protected Container() : base() { }
+
         public GLib.Value ChildGetProperty(Gtk.Widget child, string property_name)
         {
             IntPtr native_property_name = GLib.Marshaller.StringToPtrGStrdup(property_name);
@@ -80,7 +82,7 @@ namespace Gtk
 
         class ChildAccumulator
         {
-            public ArrayList Children = new ArrayList();
+            public System.Collections.Generic.List<Widget> Children = new System.Collections.Generic.List<Widget>();
 
             public void Add(Gtk.Widget widget)
             {
@@ -97,12 +99,12 @@ namespace Gtk
                 return acc.Children;
             }
         }
-		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-		delegate bool d_gtk_container_get_focus_chain(IntPtr raw, out IntPtr list_ptr);
-		static d_gtk_container_get_focus_chain gtk_container_get_focus_chain = FuncLoader.LoadFunction<d_gtk_container_get_focus_chain>(FuncLoader.GetProcAddress(GLibrary.Load(Library.Gtk), "gtk_container_get_focus_chain"));
-		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-		delegate void d_gtk_container_set_focus_chain(IntPtr raw, IntPtr list_ptr);
-		static d_gtk_container_set_focus_chain gtk_container_set_focus_chain = FuncLoader.LoadFunction<d_gtk_container_set_focus_chain>(FuncLoader.GetProcAddress(GLibrary.Load(Library.Gtk), "gtk_container_set_focus_chain"));
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        delegate bool d_gtk_container_get_focus_chain(IntPtr raw, out IntPtr list_ptr);
+        static d_gtk_container_get_focus_chain gtk_container_get_focus_chain = FuncLoader.LoadFunction<d_gtk_container_get_focus_chain>(FuncLoader.GetProcAddress(GLibrary.Load(Library.Gtk), "gtk_container_get_focus_chain"));
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        delegate void d_gtk_container_set_focus_chain(IntPtr raw, IntPtr list_ptr);
+        static d_gtk_container_set_focus_chain gtk_container_set_focus_chain = FuncLoader.LoadFunction<d_gtk_container_set_focus_chain>(FuncLoader.GetProcAddress(GLibrary.Load(Library.Gtk), "gtk_container_set_focus_chain"));
 
         public Widget[] FocusChain
         {

--- a/Source/Libs/GtkSharp/GtkSharp.metadata
+++ b/Source/Libs/GtkSharp/GtkSharp.metadata
@@ -254,6 +254,7 @@
   <attr path="/api/namespace/object[@cname='GtkApplication']/method[@name='GetAccelsForAction']/return-type" name="null_term_array">1</attr>
   <attr path="/api/namespace/object[@cname='GtkApplication']/method[@name='GetActionsForAccel']/return-type" name="null_term_array">1</attr>
   <attr path="/api/namespace/object[@cname='GtkArrow']/method[@name='Set']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GtkBin']" name="disable_void_ctor">true</attr>
   <attr path="/api/namespace/object[@cname='GtkBin']/method[@name='GetChild']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkBuilder']/constructor[@cname='gtk_builder_new_from_file']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkBuilder']/constructor[@cname='gtk_builder_new_from_resource']" name="hidden">1</attr>
@@ -329,6 +330,7 @@
   <attr path="/api/namespace/object[@cname='GtkComboBox']/method[@name='SetTitle']" name="name">SetTearoffTitle</attr> 
   <attr path="/api/namespace/object[@cname='GtkComboBox']/signal[@name='Popdown']" name="name">PoppedDown</attr> 
   <attr path="/api/namespace/object[@cname='GtkComboBox']/signal[@name='Popup']" name="name">PoppedUp</attr> 
+  <attr path="/api/namespace/object[@cname='GtkContainer']" name="disable_void_ctor">true</attr>
   <attr path="/api/namespace/object[@cname='GtkContainer']/method[@name='AddWithProperties']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkContainer']/method[@name='ChildGet']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkContainer']/method[@name='ChildGetProperty']" name="hidden">1</attr>
@@ -857,7 +859,9 @@
   <attr path="/api/namespace/object[@cname='GtkViewport']/method[@name='SetVadjustment']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkVScale']/constructor[@cname='gtk_vscale_new_with_range']" name="hidden">1</attr>
   <add-node path="/api/namespace/object[@cname='GtkWidget']"><custom-attribute>[GLib.TypeInitializer (typeof (Gtk.Widget), "ClassInit")]</custom-attribute></add-node>
+  <attr path="/api/namespace/object[@cname='GtkWidget']" name="disable_void_ctor">true</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/constructor[@cname='gtk_widget_new']" name="hidden">1</attr>
+  <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='InitTemplate']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='ClassFindStyleProperty']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='ClassListStyleProperties']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='ClassGetCssName']" name="hidden">1</attr>

--- a/Source/Libs/GtkSharp/GtkSharp.metadata
+++ b/Source/Libs/GtkSharp/GtkSharp.metadata
@@ -254,7 +254,6 @@
   <attr path="/api/namespace/object[@cname='GtkApplication']/method[@name='GetAccelsForAction']/return-type" name="null_term_array">1</attr>
   <attr path="/api/namespace/object[@cname='GtkApplication']/method[@name='GetActionsForAccel']/return-type" name="null_term_array">1</attr>
   <attr path="/api/namespace/object[@cname='GtkArrow']/method[@name='Set']" name="hidden">1</attr>
-  <attr path="/api/namespace/object[@cname='GtkBin']" name="disable_void_ctor">true</attr>
   <attr path="/api/namespace/object[@cname='GtkBin']/method[@name='GetChild']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkBuilder']/constructor[@cname='gtk_builder_new_from_file']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkBuilder']/constructor[@cname='gtk_builder_new_from_resource']" name="hidden">1</attr>
@@ -330,7 +329,6 @@
   <attr path="/api/namespace/object[@cname='GtkComboBox']/method[@name='SetTitle']" name="name">SetTearoffTitle</attr> 
   <attr path="/api/namespace/object[@cname='GtkComboBox']/signal[@name='Popdown']" name="name">PoppedDown</attr> 
   <attr path="/api/namespace/object[@cname='GtkComboBox']/signal[@name='Popup']" name="name">PoppedUp</attr> 
-  <attr path="/api/namespace/object[@cname='GtkContainer']" name="disable_void_ctor">true</attr>
   <attr path="/api/namespace/object[@cname='GtkContainer']/method[@name='AddWithProperties']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkContainer']/method[@name='ChildGet']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkContainer']/method[@name='ChildGetProperty']" name="hidden">1</attr>
@@ -859,7 +857,6 @@
   <attr path="/api/namespace/object[@cname='GtkViewport']/method[@name='SetVadjustment']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkVScale']/constructor[@cname='gtk_vscale_new_with_range']" name="hidden">1</attr>
   <add-node path="/api/namespace/object[@cname='GtkWidget']"><custom-attribute>[GLib.TypeInitializer (typeof (Gtk.Widget), "ClassInit")]</custom-attribute></add-node>
-  <attr path="/api/namespace/object[@cname='GtkWidget']" name="disable_void_ctor">true</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/constructor[@cname='gtk_widget_new']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='InitTemplate']" name="hidden">1</attr>
   <attr path="/api/namespace/object[@cname='GtkWidget']/method[@name='ClassFindStyleProperty']" name="hidden">1</attr>

--- a/Source/Libs/GtkSharp/HandlerNotFoundException.cs
+++ b/Source/Libs/GtkSharp/HandlerNotFoundException.cs
@@ -1,0 +1,112 @@
+// HandlerNotFoundException.cs - exception for Gtk.Builder
+//
+// Authors: Stephane Delcroix  <stephane@delcroix.org>
+// The biggest part of this code is adapted from glade#, by
+//	Ricardo Fernández Pascual <ric@users.sourceforge.net>
+//	Rachel Hestilow <hestilow@ximian.com>
+//
+// Copyright (c) 2002 Ricardo Fernández Pascual
+// Copyright (c) 2003 Rachel Hestilow
+// Copyright (c) 2008 Novell, Inc.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of version 2 of the Lesser GNU General
+// Public License as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this program; if not, write to the
+// Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+// Boston, MA 02111-1307, USA.
+
+using System;
+
+namespace Gtk
+{
+		[System.Serializable]
+		public class HandlerNotFoundException : SystemException
+		{
+			string handler_name;
+			string signal_name;
+			System.Reflection.EventInfo evnt;
+			Type delegate_type;
+		
+			public HandlerNotFoundException (string handler_name, string signal_name,
+							 System.Reflection.EventInfo evnt, Type delegate_type)
+				: this (handler_name, signal_name, evnt, delegate_type, null)
+			{
+			}
+		
+			public HandlerNotFoundException (string handler_name, string signal_name,
+							 System.Reflection.EventInfo evnt, Type delegate_type, Exception inner)
+				: base ("No handler " + handler_name + " found for signal " + signal_name,
+					inner)
+			{
+				this.handler_name = handler_name;
+				this.signal_name = signal_name;
+				this.evnt = evnt;
+				this.delegate_type = delegate_type;
+			}
+		
+			public HandlerNotFoundException (string message, string handler_name, string signal_name,
+							 System.Reflection.EventInfo evnt, Type delegate_type)
+				: base ((message != null) ? message : "No handler " + handler_name + " found for signal " + signal_name,
+					null)
+			{
+				this.handler_name = handler_name;
+				this.signal_name = signal_name;
+				this.evnt = evnt;
+				this.delegate_type = delegate_type;
+			}
+		
+			protected HandlerNotFoundException (System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
+				: base (info, context)
+			{
+				handler_name = info.GetString ("HandlerName");
+				signal_name = info.GetString ("SignalName");
+				evnt = info.GetValue ("Event", typeof (System.Reflection.EventInfo)) as System.Reflection.EventInfo;
+				delegate_type = info.GetValue ("DelegateType", typeof (Type)) as Type;
+			}
+		
+			public string HandlerName
+			{
+				get {
+					return handler_name;
+				}
+			}
+		
+			public string SignalName
+			{
+				get {
+					return signal_name;
+				}
+			}
+		
+			public System.Reflection.EventInfo Event
+			{
+				get {
+					return evnt;
+				}
+			}
+		
+			public Type DelegateType
+			{
+				get {
+					return delegate_type;
+				}
+			}
+		
+			public override void GetObjectData (System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
+			{
+				base.GetObjectData (info, context);
+				info.AddValue ("HandlerName", handler_name);
+				info.AddValue ("SignalName", signal_name);
+				info.AddValue ("Event", evnt);
+				info.AddValue ("DelegateType", delegate_type);
+			}
+		}
+}

--- a/Source/Libs/GtkSharp/SignalConnector.cs
+++ b/Source/Libs/GtkSharp/SignalConnector.cs
@@ -1,0 +1,204 @@
+// SignalConnector.cs - helper for Gtk.Builder
+//
+// Authors: Stephane Delcroix  <stephane@delcroix.org>
+// The biggest part of this code is adapted from glade#, by
+//	Ricardo Fernández Pascual <ric@users.sourceforge.net>
+//	Rachel Hestilow <hestilow@ximian.com>
+//
+// Copyright (c) 2002 Ricardo Fernández Pascual
+// Copyright (c) 2003 Rachel Hestilow
+// Copyright (c) 2008 Novell, Inc.
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of version 2 of the Lesser GNU General
+// Public License as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this program; if not, write to the
+// Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+// Boston, MA 02111-1307, USA.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Gtk
+{
+	internal class SignalConnector
+	{
+		Type handler_type;
+		object handler;
+		internal object template_object_instance;
+
+		public SignalConnector (object handler)
+		{
+			this.handler = handler;
+			handler_type = handler.GetType ();
+		}
+	
+		public SignalConnector (Type handler_type)
+		{
+			this.handler = null;
+			this.handler_type = handler_type;
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+		delegate void d_gtk_builder_connect_signals_full(IntPtr raw, GtkSharp.BuilderConnectFuncNative func, IntPtr user_data);
+		static d_gtk_builder_connect_signals_full gtk_builder_connect_signals_full = FuncLoader.LoadFunction<d_gtk_builder_connect_signals_full>(FuncLoader.GetProcAddress(GLibrary.Load(Library.Gtk), "gtk_builder_connect_signals_full"));
+	
+		public void ConnectSignals(Builder builder) {
+			GtkSharp.BuilderConnectFuncWrapper func_wrapper = new GtkSharp.BuilderConnectFuncWrapper (new BuilderConnectFunc (ConnectFunc));
+			gtk_builder_connect_signals_full(builder.Handle, func_wrapper.NativeDelegate, IntPtr.Zero);
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+		delegate IntPtr d_gtk_widget_class_set_connect_func(IntPtr class_ptr, GtkSharp.BuilderConnectFuncNative connect_func, IntPtr data);
+		static d_gtk_widget_class_set_connect_func gtk_widget_class_set_connect_func = FuncLoader.LoadFunction<d_gtk_widget_class_set_connect_func>(FuncLoader.GetProcAddress(GLibrary.Load(Library.Gtk), nameof(gtk_widget_class_set_connect_func)));
+
+		public void ConnectSignals(GLib.GType gtype)
+		{
+			var func_wrapper = new GtkSharp.BuilderConnectFuncWrapper (new BuilderConnectFunc (ConnectFunc));
+			gtk_widget_class_set_connect_func(gtype.GetClassPtr (), func_wrapper.NativeDelegate, IntPtr.Zero);
+		}
+	
+		public void ConnectFunc (Builder builder, GLib.Object objekt, string signal_name, string handler_name, GLib.Object connect_object, GLib.ConnectFlags flags)
+		{
+			/* search for the event to connect */
+			System.Reflection.MemberInfo[] evnts = objekt.GetType ().
+				FindMembers (System.Reflection.MemberTypes.Event,
+						System.Reflection.BindingFlags.Instance
+						| System.Reflection.BindingFlags.Static
+						| System.Reflection.BindingFlags.Public
+						| System.Reflection.BindingFlags.NonPublic,
+						new System.Reflection.MemberFilter (SignalFilter), signal_name);
+			foreach (System.Reflection.EventInfo ei in evnts) {
+				bool connected = false;
+				System.Reflection.MethodInfo add = ei.GetAddMethod ();
+				System.Reflection.ParameterInfo[] addpi = add.GetParameters ();
+				if (addpi.Length == 1) { /* this should be always true, unless there's something broken */
+					Type delegate_type = addpi[0].ParameterType;
+	
+					/* look for an instance method */
+					if (connect_object != null || handler != null)
+						try {
+							Delegate d = Delegate.CreateDelegate (delegate_type, connect_object != null ? connect_object : handler, handler_name);
+							add.Invoke (objekt, new object[] { d } );
+							connected = true;
+						} catch (ArgumentException) { /* ignore if there is not such instance method */
+						}
+
+					/* look for an instance method for template */
+					if (!connected && template_object_instance != null)
+						try {
+							Delegate d = Delegate.CreateDelegate (delegate_type, template_object_instance, handler_name);
+							add.Invoke (objekt, new object[] { d });
+							connected = true;
+						} catch (ArgumentException) { /* ignore if there is not such instance method */
+						}
+
+					/* look for a static method if no instance method has been found */
+					if (!connected && handler_type != null)
+						try  {
+							Delegate d = Delegate.CreateDelegate (delegate_type, handler_type, handler_name);
+							add.Invoke (objekt, new object[] { d } );
+							connected = true;
+						} catch (ArgumentException) { /* ignore if there is not such static method */
+						}
+	
+					if (!connected) {
+						string msg = ExplainError (ei.Name, delegate_type, handler_type, handler_name);
+						throw new HandlerNotFoundException (msg, handler_name, signal_name, ei, delegate_type);
+					}
+				}
+			}
+		}
+	
+		static bool SignalFilter (System.Reflection.MemberInfo m, object filterCriteria)
+		{
+			string signame = (filterCriteria as string);
+			object[] attrs = m.GetCustomAttributes (typeof (GLib.SignalAttribute), false);
+			if (attrs.Length > 0)
+			{
+				foreach (GLib.SignalAttribute a in attrs)
+				{
+					if (signame == a.CName)
+					{
+						return true;
+					}
+				}
+				return false;
+			}
+			else
+			{
+				/* this tries to match the names when no attributes are present.
+					It is only a fallback. */
+				signame = signame.ToLower ().Replace ("_", "");
+				string evname = m.Name.ToLower ();
+				return signame == evname;
+			}
+		}
+	
+		static string GetSignature (System.Reflection.MethodInfo method)
+		{
+			if (method == null)
+				return null;
+	
+			System.Reflection.ParameterInfo [] parameters = method.GetParameters ();
+			System.Text.StringBuilder sb = new System.Text.StringBuilder ();
+			sb.Append ('(');
+			foreach (System.Reflection.ParameterInfo info in parameters) {
+				sb.Append (info.ParameterType.ToString ());
+				sb.Append (',');
+			}
+			if (sb.Length != 0)
+				sb.Length--;
+	
+			sb.Append (')');
+			return sb.ToString ();
+		}
+	
+		static string GetSignature (Type delegate_type)
+		{
+			System.Reflection.MethodInfo method = delegate_type.GetMethod ("Invoke");
+			return GetSignature (method);
+		}
+	
+		static string GetSignature (Type klass, string method_name)
+		{
+			const System.Reflection.BindingFlags flags = System.Reflection.BindingFlags.NonPublic |
+							System.Reflection.BindingFlags.Public |
+							System.Reflection.BindingFlags.Static |
+							System.Reflection.BindingFlags.Instance;
+
+			try {
+				System.Reflection.MethodInfo method = klass.GetMethod (method_name, flags);
+				return GetSignature (method);
+			} catch {
+				// May be more than one method with that name and none matches
+				return null;
+			}
+		}
+
+		static string ExplainError (string event_name, Type deleg, Type klass, string method)
+		{
+			if (deleg == null || klass == null || method == null)
+				return null;
+	
+			System.Text.StringBuilder sb = new System.Text.StringBuilder ();
+			string expected = GetSignature (deleg);
+			string actual = GetSignature (klass, method);
+			if (actual == null)
+				return null;
+
+			sb.AppendFormat ("The handler for the event {0} should take '{1}', " +
+				"but the signature of the provided handler ('{2}') is '{3}'\n",
+				event_name, expected, method, actual);
+			
+			return sb.ToString ();
+		}
+	}
+}

--- a/Source/Libs/GtkSharp/TemplateAttribute.cs
+++ b/Source/Libs/GtkSharp/TemplateAttribute.cs
@@ -1,0 +1,44 @@
+// TemplateAttribute.cs - Template attribute
+//
+// Author:
+//	 Marcel Tiede
+//
+// Copyright (c) 2019 Marcel Tiede
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of version 2 of the Lesser GNU General 
+// Public License as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this program; if not, write to the
+// Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+// Boston, MA 02111-1307, USA.
+
+namespace Gtk
+{
+    using System;
+    
+    [AttributeUsage(AttributeTargets.Class)]
+    public class TemplateAttribute : Attribute
+    {
+        public string Ui { get; }
+
+        public bool ThrowOnUnknownChild { get; }
+
+        public TemplateAttribute(string ui)
+        {
+            Ui = ui;
+        }
+
+        public TemplateAttribute(string ui, bool throwOnUnknownChild)
+        {
+            Ui = ui;
+            ThrowOnUnknownChild = throwOnUnknownChild;
+        }
+    }
+}

--- a/Source/Libs/GtkSharp/Widget.cs
+++ b/Source/Libs/GtkSharp/Widget.cs
@@ -321,11 +321,6 @@ namespace Gtk {
 				SetCssName (gtype, attr.Name);
 		}
 
-		protected Widget () : base (IntPtr.Zero)
-		{
-			CreateNativeObject (Array.Empty<string> (), Array.Empty<GLib.Value> ());
-		}
-
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		delegate void d_gtk_widget_init_template(IntPtr raw);
 		static d_gtk_widget_init_template gtk_widget_init_template = FuncLoader.LoadFunction<d_gtk_widget_init_template>(FuncLoader.GetProcAddress(GLibrary.Load(Library.Gtk), "gtk_widget_init_template"));

--- a/Source/Libs/GtkSharp/Widget.cs
+++ b/Source/Libs/GtkSharp/Widget.cs
@@ -3,7 +3,9 @@
 //
 // Authors: Rachel Hestilow <hestilow@ximian.com>,
 //          Brad Taylor <brad@getcoded.net>
+//          Marcel Tiede
 //
+// Copyright (C) 2019 Marcel Tiede
 // Copyright (C) 2007 Brad Taylor
 // Copyright (C) 2002 Rachel Hestilow 
 //
@@ -35,6 +37,22 @@ namespace Gtk {
 			get { return Window; }
 			set { Window = value; }
 		}
+
+		struct TemplateData
+		{
+			public Dictionary<FieldInfo, string> FieldBindings;
+			public SignalConnector SignalConnector;
+			public bool ThrowOnUnknownChild;
+
+			public static TemplateData Create()
+			{
+				var res = new TemplateData();
+				res.FieldBindings = new Dictionary<FieldInfo, string>();
+				return res;
+			}
+		}
+
+		private static Dictionary<Type, TemplateData> Templates = new Dictionary<Type, TemplateData>();
 
 		public void AddAccelerator (string accel_signal, AccelGroup accel_group, AccelKey accel_key)
 		{
@@ -196,8 +214,13 @@ namespace Gtk {
 
 		static void ClassInit (GLib.GType gtype, Type t)
 		{
-			InitCssName(gtype, t);
+			InitBindings (gtype, t);
+			InitTemplateForType (gtype, t);
+			InitCssName (gtype, t);
+		}
 
+		static void InitBindings (GLib.GType gtype, Type t)
+		{
 			object[] attrs = t.GetCustomAttributes (typeof (BindingAttribute), true);
 			if (attrs.Length == 0) return;
 
@@ -232,11 +255,107 @@ namespace Gtk {
 			GLib.Marshaller.Free (native_signame);
 		}
 
+		static void InitTemplateForType (GLib.GType gtype, Type type)
+		{
+			var attr = type.GetCustomAttribute<TemplateAttribute> (true);
+			if (attr == null) return;
+
+			var data = TemplateData.Create ();
+			data.ThrowOnUnknownChild = attr.ThrowOnUnknownChild;
+			var resource_name = attr.Ui;
+			var resource_stream = type.Assembly.GetManifestResourceStream (resource_name);
+
+			if (resource_stream == null)
+				throw new Exception ("Template resource '" + resource_name + "' not found");
+
+			SetTemplateFromStream (gtype, resource_stream);
+			BindTemplateChildren (gtype, type, data.FieldBindings);
+			
+			data.SignalConnector = new SignalConnector (type);
+			data.SignalConnector.ConnectSignals (gtype);
+			Templates[type] = data;
+		}
+
+		delegate IntPtr d_gtk_widget_class_set_template(IntPtr class_ptr, IntPtr template_bytes);
+		static d_gtk_widget_class_set_template gtk_widget_class_set_template = FuncLoader.LoadFunction<d_gtk_widget_class_set_template>(FuncLoader.GetProcAddress(GLibrary.Load(Library.Gtk), "gtk_widget_class_set_template"));
+
+		static void SetTemplateFromStream (GLib.GType gtype, System.IO.Stream resource)
+		{
+			var buffer = new byte[(int)resource.Length];
+			resource.Read (buffer, 0, buffer.Length);
+			resource.Dispose ();
+
+			var bytes = new GLib.Bytes (buffer);
+			gtk_widget_class_set_template (gtype.GetClassPtr (), bytes.Handle);
+			bytes.Dispose ();
+		}
+
+		delegate IntPtr d_gtk_widget_class_bind_template_child_full(IntPtr class_ptr, IntPtr name, bool internal_child, IntPtr struct_offset);
+		static d_gtk_widget_class_bind_template_child_full gtk_widget_class_bind_template_child_full = FuncLoader.LoadFunction<d_gtk_widget_class_bind_template_child_full>(FuncLoader.GetProcAddress(GLibrary.Load(Library.Gtk), "gtk_widget_class_bind_template_child_full"));
+
+		static void BindTemplateChildren (GLib.GType gtype, Type type, Dictionary<FieldInfo, string> fields)
+		{
+			const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly | BindingFlags.Instance;
+
+			foreach (var field in type.GetFields (flags))
+			{
+				var attr = field.GetCustomAttribute<ChildAttribute> (true);
+
+				if (attr == null)
+					continue;
+
+				var name = attr.Name ?? field.Name;
+
+				var native_name = GLib.Marshaller.StringToPtrGStrdup (name);
+				gtk_widget_class_bind_template_child_full (gtype.GetClassPtr (), native_name, attr.Internal, new IntPtr ((long)0));
+				GLib.Marshaller.Free (native_name);
+
+				fields[field] = name;
+			}
+		}
+
 		static void InitCssName (GLib.GType gtype, Type t)
 		{
 			CssNameAttribute attr = t.GetCustomAttribute<CssNameAttribute>(true);
 			if (attr != null)
 				SetCssName (gtype, attr.Name);
+		}
+
+		protected Widget () : base (IntPtr.Zero)
+		{
+			CreateNativeObject (Array.Empty<string> (), Array.Empty<GLib.Value> ());
+		}
+
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+		delegate void d_gtk_widget_init_template(IntPtr raw);
+		static d_gtk_widget_init_template gtk_widget_init_template = FuncLoader.LoadFunction<d_gtk_widget_init_template>(FuncLoader.GetProcAddress(GLibrary.Load(Library.Gtk), "gtk_widget_init_template"));
+
+		void InitTemplateForInstance ()
+		{
+			var type = GetType ();
+			if (Templates.TryGetValue(type, out TemplateData data))
+			{
+				GLib.GType gtype = LookupGType (type);
+				data.SignalConnector.template_object_instance = this;
+				gtk_widget_init_template (Handle);
+				data.SignalConnector.template_object_instance = null;
+				foreach (KeyValuePair<FieldInfo, string> pair in data.FieldBindings)
+				{
+					FieldInfo field = pair.Key;
+					string name = pair.Value;
+					GLib.Object child = GetTemplateChild (gtype, name);
+					
+					if (child != null)
+					{
+						const BindingFlags flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly | BindingFlags.Instance;
+						field.SetValue (this, child, flags, null, null);
+					}
+					else if (data.ThrowOnUnknownChild)
+					{
+						throw new Exception ("Unknown child in template for type '" + type + "'");
+					}
+				}
+			}
 		}
 
 		public object StyleGetProperty (string property_name)
@@ -396,6 +515,7 @@ namespace Gtk {
 		protected override void CreateNativeObject (string[] names, GLib.Value[] vals)
 		{
 			base.CreateNativeObject (names, vals);
+			InitTemplateForInstance ();
 		}
 
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]

--- a/Source/Samples/Sections/Widgets/CompositeWidgetSection.cs
+++ b/Source/Samples/Sections/Widgets/CompositeWidgetSection.cs
@@ -1,0 +1,47 @@
+using System;
+using Gtk;
+
+namespace Samples
+{
+    [Section(ContentType = typeof(CompositeWidget), Category = Category.Widgets)]
+    class CompositeWidgetSection : ListSection
+    {
+        public CompositeWidgetSection()
+        {
+            AddItem("CompositeWidget:", new CompositeWidget());
+            AddItem("Other instance:", new CompositeWidget());
+        }
+    }
+
+    [Template("CompositeWidget.glade", true)]
+    [GLib.TypeName(nameof(CompositeWidget))]
+    class CompositeWidget : Bin
+    {
+#pragma warning disable CS0649, CS0169
+        [Child] Button btn1;
+        [Child] Button btn2;
+        [Child("label")] Entry entry;
+#pragma warning restore CS0649, CS0169
+
+        public CompositeWidget()
+        {
+            // Base constructor sets [Child] fields
+            // if [Template(throwOnUnknownChild = true) and GTK can't bind any [Child] field then base constructor throws
+            // GTK writes invalid field/widget name in console (project <OutputType> must be Exe to see console on Windows OS)
+            System.Diagnostics.Debug.Assert(btn1 != null);
+            System.Diagnostics.Debug.Assert(btn2 != null);
+            System.Diagnostics.Debug.Assert(entry != null);
+        }
+
+        private void on_btn1_clicked(object sender, EventArgs e)
+        {
+            entry.Text = DateTime.Now.ToString();
+            ApplicationOutput.WriteLine(this, "Instance handler clicked");
+        }
+
+        private static void on_btn2_clicked(object sender, EventArgs e)
+        {
+            ApplicationOutput.WriteLine("Static handler clicked");
+        }
+    }
+}

--- a/Source/Samples/Sections/Widgets/CustomWidgets/CompositeWidget.glade
+++ b/Source/Samples/Sections/Widgets/CustomWidgets/CompositeWidget.glade
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
+<interface>
+  <requires lib="gtk+" version="3.18"/>
+  <template class="CompositeWidget" parent="GtkBin">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <child>
+              <object class="GtkButton" id="btn1">
+                <property name="label" translatable="yes">Instance handler</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="margin-start">3</property>
+                <property name="margin-end">3</property>
+                <property name="margin-top">3</property>
+                <property name="margin-bottom">3</property>
+                <signal name="clicked" handler="on_btn1_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="btn2">
+                <property name="label" translatable="yes">Static handler</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="margin-start">3</property>
+                <property name="margin-end">3</property>
+                <property name="margin-top">3</property>
+                <property name="margin-bottom">3</property>
+                <signal name="clicked" handler="on_btn2_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkEntry" id="label">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="margin-start">3</property>
+            <property name="margin-end">3</property>
+            <property name="margin-top">3</property>
+            <property name="margin-bottom">3</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>


### PR DESCRIPTION
Second version of template support.
Most code is from https://github.com/GtkSharp/GtkSharp/pull/90.
Auto signal connections are working, see samples.
Also added check for unknown fields (when GTK can't find widget in .glade).

But no .NET project templates, sorry.