### PR TITLE
optimize array empty & avoid empty list creation in ctor

### DIFF
--- a/Source/Libs/GLibSharp/Marshaller.cs
+++ b/Source/Libs/GLibSharp/Marshaller.cs
@@ -187,7 +187,7 @@ namespace GLib {
 		public static string[] NullTermPtrToStringArray (IntPtr null_term_array, bool owned)
 		{
 			if (null_term_array == IntPtr.Zero)
-				return new string [0];
+				return Array.Empty<string> ();
 
 			int count = 0;
 			var result = new List<string> ();
@@ -206,7 +206,7 @@ namespace GLib {
 		public static string[] PtrToStringArrayGFree (IntPtr string_array)
 		{
 			if (string_array == IntPtr.Zero)
-				return new string [0];
+				return Array.Empty<string> ();
 	
 			int count = 0;
 			while (Marshal.ReadIntPtr (string_array, count*IntPtr.Size) != IntPtr.Zero)

--- a/Source/Libs/GLibSharp/Object.cs
+++ b/Source/Libs/GLibSharp/Object.cs
@@ -396,7 +396,7 @@ namespace GLib {
 
 					foreach (object attr in baseinfo.GetCustomAttributes (typeof (DefaultSignalHandlerAttribute), false)) {
 						DefaultSignalHandlerAttribute sigattr = attr as DefaultSignalHandlerAttribute;
-						MethodInfo connector = sigattr.Type.GetMethod (sigattr.ConnectionMethod, BindingFlags.Static | BindingFlags.NonPublic, null, new Type[] { typeof (GType) }, new ParameterModifier [0]);
+						MethodInfo connector = sigattr.Type.GetMethod (sigattr.ConnectionMethod, BindingFlags.Static | BindingFlags.NonPublic, null, new Type[] { typeof (GType) }, Array.Empty<ParameterModifier> ());
 						object[] parms = new object [1];
 						parms [0] = gtype;
 						connector.Invoke (null, parms);
@@ -550,7 +550,7 @@ namespace GLib {
 			if (!props.TryGetValue (param_spec, out prop))
 				return;
 
-			value.Val = prop.GetValue (obj, new object [0]);
+			value.Val = prop.GetValue (obj, Array.Empty<object> ());
 		}
 
 		static GetPropertyDelegate get_property_handler;
@@ -601,7 +601,7 @@ namespace GLib {
 			if (!props.TryGetValue (param_spec, out prop))
 				return;
 
-			prop.SetValue (obj, value.Val, new object [0]);
+			prop.SetValue (obj, value.Val, Array.Empty<object> ());
 		}
 
 		static SetPropertyDelegate set_property_handler;
@@ -648,7 +648,7 @@ namespace GLib {
 
 		protected Object ()
 		{
-			CreateNativeObject (new string [0], new GLib.Value [0]);
+			CreateNativeObject (Array.Empty<string> (), Array.Empty<Value> ());
 		}
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
 		delegate IntPtr d_g_object_new(IntPtr gtype, IntPtr dummy);

--- a/Source/Libs/GLibSharp/SignalClosure.cs
+++ b/Source/Libs/GLibSharp/SignalClosure.cs
@@ -155,7 +155,7 @@ namespace GLib {
 					return;
 				}
 
-				SignalArgs args = Activator.CreateInstance (closure.args_type, new object [0]) as SignalArgs;
+				SignalArgs args = Activator.CreateInstance (closure.args_type, Array.Empty<object> ()) as SignalArgs;
 				args.Args = new object [n_param_vals - 1];
 				GLib.Value[] vals = new GLib.Value [n_param_vals - 1];
 				for (int i = 1; i < n_param_vals; i++) {

--- a/Source/Libs/GdkSharp/Device.cs
+++ b/Source/Libs/GdkSharp/Device.cs
@@ -45,7 +45,7 @@ namespace Gdk {
 				gdk_device_free_history (coords_handle, count);
 				return result;
 			} else
-				return new TimeCoord [0];
+				return Array.Empty<TimeCoord> ();
 		}
 	}
 }

--- a/Source/Libs/GdkSharp/Display.cs
+++ b/Source/Libs/GdkSharp/Display.cs
@@ -73,7 +73,7 @@ namespace Gdk {
 		{
 			IntPtr raw_ret = gdk_display_list_devices (Handle);
 			if (raw_ret == IntPtr.Zero)
-				return new Device [0];
+				return Array.Empty<Device> ();
 			GLib.List list = new GLib.List(raw_ret);
 			Device[] result = new Device [list.Count];
 			for (int i = 0; i < list.Count; i++)

--- a/Source/Libs/GdkSharp/DisplayManager.cs
+++ b/Source/Libs/GdkSharp/DisplayManager.cs
@@ -32,7 +32,7 @@ namespace Gdk {
 		{
 			IntPtr raw_ret = gdk_display_manager_list_displays (Handle);
 			if (raw_ret == IntPtr.Zero)
-				return new Display [0];
+				return Array.Empty<Display> ();
 			GLib.SList list = new GLib.SList(raw_ret);
 			Display[] result = new Display [list.Count];
 			for (int i = 0; i < list.Count; i++)

--- a/Source/Libs/GdkSharp/Global.cs
+++ b/Source/Libs/GdkSharp/Global.cs
@@ -33,7 +33,7 @@ namespace Gdk {
 		{
 			IntPtr raw_ret = gdk_list_visuals ();
 			if (raw_ret == IntPtr.Zero)
-				return new Visual [0];
+				return Array.Empty<Visual> ();
 			GLib.List list = new GLib.List(raw_ret);
 			Visual[] result = new Visual [list.Count];
 			for (int i = 0; i < list.Count; i++)

--- a/Source/Libs/GdkSharp/Keymap.cs
+++ b/Source/Libs/GdkSharp/Keymap.cs
@@ -46,8 +46,8 @@ namespace Gdk {
 				GLib.Marshaller.Free (key_ptr);
 				GLib.Marshaller.Free (keyval_ptr);
 			} else {
-				keys = new KeymapKey [0];
-				keyvals = new uint [0];
+				keys = Array.Empty<KeymapKey> ();
+				keyvals = Array.Empty<uint> ();
 			}
 		}
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
@@ -67,7 +67,7 @@ namespace Gdk {
 				GLib.Marshaller.Free (key_ptr);
 				return result;
 			} else
-				return new KeymapKey [0];
+				return Array.Empty<KeymapKey> ();
 		}
 	}
 }

--- a/Source/Libs/GdkSharp/Pixbuf.cs
+++ b/Source/Libs/GdkSharp/Pixbuf.cs
@@ -262,7 +262,7 @@ namespace Gdk {
 			get {
 				IntPtr list_ptr = gdk_pixbuf_get_formats ();
 				if (list_ptr == IntPtr.Zero)
-					return new PixbufFormat [0];
+					return Array.Empty<PixbufFormat> ();
 				GLib.SList list = new GLib.SList (list_ptr, typeof (PixbufFormat));
 				PixbufFormat[] result = new PixbufFormat [list.Count];
 				for (int i = 0; i < list.Count; i++)
@@ -310,7 +310,7 @@ namespace Gdk {
 
 		public unsafe byte[] SaveToBuffer (string type)
 		{
-			return SaveToBuffer (type, new string [0], new string [0]);
+			return SaveToBuffer (type, Array.Empty<string> (), Array.Empty<string> ());
 		}
 
 		public unsafe byte[] SaveToBuffer (string type, string[] option_keys, string[] option_values) 
@@ -339,7 +339,7 @@ namespace Gdk {
 
 		public unsafe void SaveToCallback (PixbufSaveFunc save_func, string type)
 		{
-			SaveToCallback (save_func, type, new string [0], new string [0]);
+			SaveToCallback (save_func, type, Array.Empty<string> (), Array.Empty<string> ());
 		}
 
 		public unsafe void SaveToCallback (PixbufSaveFunc save_func, string type, string[] option_keys, string[] option_values) 

--- a/Source/Libs/GdkSharp/Screen.cs
+++ b/Source/Libs/GdkSharp/Screen.cs
@@ -33,7 +33,7 @@ namespace Gdk {
 			get {
 				IntPtr raw_ret = gdk_screen_get_toplevel_windows (Handle);
 				if (raw_ret == IntPtr.Zero)
-					return new Window [0];
+					return Array.Empty<Window> ();
 				GLib.List list = new GLib.List(raw_ret);
 				Window[] result = new Window [list.Count];
 				for (int i = 0; i < list.Count; i++)
@@ -49,7 +49,7 @@ namespace Gdk {
 		{
 			IntPtr raw_ret = gdk_screen_list_visuals (Handle);
 			if (raw_ret == IntPtr.Zero)
-				return new Visual [0];
+				return Array.Empty<Visual> ();
 			GLib.List list = new GLib.List(raw_ret);
 			Visual[] result = new Visual [list.Count];
 			for (int i = 0; i < list.Count; i++)

--- a/Source/Libs/GdkSharp/TextProperty.cs
+++ b/Source/Libs/GdkSharp/TextProperty.cs
@@ -35,7 +35,7 @@ namespace Gdk {
 			int count = gdk_text_property_to_utf8_list_for_display (display.Handle, encoding.Handle, format, text, length, out list_ptr);
 
 			if (count == 0)
-				return new string [0];
+				return Array.Empty<string> ();
 
 			string[] result = new string [count];
 			for (int i = 0; i < count; i++) {

--- a/Source/Libs/GdkSharp/Window.cs
+++ b/Source/Libs/GdkSharp/Window.cs
@@ -56,7 +56,7 @@ namespace Gdk {
 			get {
 				IntPtr raw_ret = gdk_window_get_children(Handle);
 				if (raw_ret == IntPtr.Zero)
-					return new Window [0];
+					return Array.Empty<Window> ();
 				GLib.List list = new GLib.List(raw_ret);
 				Window[] result = new Window [list.Count];
 				for (int i = 0; i < list.Count; i++)

--- a/Source/Libs/GtkSharp/Accel.cs
+++ b/Source/Libs/GtkSharp/Accel.cs
@@ -128,7 +128,7 @@ namespace Gtk {
 		{
 			IntPtr raw_ret = gtk_accel_groups_from_object(obj.Handle);
 			if (raw_ret == IntPtr.Zero)
-				return new AccelGroup [0];
+				return Array.Empty<AccelGroup> ();
 			GLib.SList list = new GLib.SList(raw_ret);
 			AccelGroup[] result = new AccelGroup [list.Count];
 			for (int i = 0; i < list.Count; i++)

--- a/Source/Libs/GtkSharp/Adjustment.cs
+++ b/Source/Libs/GtkSharp/Adjustment.cs
@@ -16,6 +16,8 @@
 // Boston, MA 02111-1307, USA.
 //
 
+using GLib;
+
 namespace Gtk {
 
 	using System;
@@ -29,7 +31,7 @@ namespace Gtk {
 		public Adjustment (double value, double lower, double upper, double step_increment, double page_increment, double page_size) : base (IntPtr.Zero)
 		{
 			if (GetType () != typeof (Adjustment)) {
-				CreateNativeObject (new string [0], new GLib.Value [0]);
+				CreateNativeObject (Array.Empty<string> (), Array.Empty<Value> ());
 				Value = value;
 				Lower = lower;
 				Upper = upper;

--- a/Source/Libs/GtkSharp/Application.cs
+++ b/Source/Libs/GtkSharp/Application.cs
@@ -87,7 +87,7 @@ namespace Gtk {
 			// not interested in.
 
 			if (argc <= 1)
-				args = new string[0];
+				args = Array.Empty<string> ();
 			else {
 				progargs = argv.GetArgs (argc);
 				args = new string[argc - 1];

--- a/Source/Libs/GtkSharp/CheckMenuItem.cs
+++ b/Source/Libs/GtkSharp/CheckMenuItem.cs
@@ -18,6 +18,8 @@
 // Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 // Boston, MA 02111-1307, USA.
 
+using GLib;
+
 namespace Gtk {
 
 	using System;
@@ -31,7 +33,7 @@ namespace Gtk {
 		public CheckMenuItem (string label) : base (IntPtr.Zero)
 		{
 			if (GetType() != typeof (CheckMenuItem)) {
-				CreateNativeObject (new string [0], new GLib.Value [0]);
+				CreateNativeObject (Array.Empty<string> (), Array.Empty<Value> ());
 				AccelLabel al = new AccelLabel ("");
 				al.TextWithMnemonic = label;
 				al.SetAlignment (0.0f, 0.5f);

--- a/Source/Libs/GtkSharp/Clipboard.cs
+++ b/Source/Libs/GtkSharp/Clipboard.cs
@@ -83,7 +83,7 @@ namespace Gtk {
 			IntPtr raw_ret = gtk_clipboard_wait_for_rich_text (Handle, buffer == null ? IntPtr.Zero : buffer.Handle, out format_as_native, out length);
 			format = format_as_native == IntPtr.Zero ? null : (Gdk.Atom) GLib.Opaque.GetOpaque (format_as_native, typeof (Gdk.Atom), false);
 			if (raw_ret == IntPtr.Zero)
-				return new byte [0];
+				return Array.Empty<byte> ();
 			int sz = (int) (uint) length;
 			byte[] ret = new byte [sz];
 			Marshal.Copy (ret, 0, raw_ret, sz);

--- a/Source/Libs/GtkSharp/Container.cs
+++ b/Source/Libs/GtkSharp/Container.cs
@@ -111,7 +111,7 @@ namespace Gtk
                 IntPtr list_ptr;
                 bool success = gtk_container_get_focus_chain(Handle, out list_ptr);
                 if (!success)
-                    return new Widget[0];
+                    return Array.Empty<Widget> ();
 
                 GLib.List list = new GLib.List(list_ptr);
                 Widget[] result = new Widget[list.Count];

--- a/Source/Libs/GtkSharp/FileChooserDialog.cs
+++ b/Source/Libs/GtkSharp/FileChooserDialog.cs
@@ -21,6 +21,8 @@
 // Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 // Boston, MA 02111-1307, USA.
 
+using GLib;
+
 namespace Gtk {
 
 	using System;
@@ -34,7 +36,7 @@ namespace Gtk {
 		public FileChooserDialog (string title, Window parent, FileChooserAction action, params object[] button_data) : base (IntPtr.Zero)
 		{
 			if (GetType () != typeof (FileChooserDialog)) {
-				CreateNativeObject (new string[0], new GLib.Value[0]);
+				CreateNativeObject (Array.Empty<string> (), Array.Empty<Value> ());
 				Title = title;
 				if (parent != null)
 					TransientFor = parent;

--- a/Source/Libs/GtkSharp/IconTheme.cs
+++ b/Source/Libs/GtkSharp/IconTheme.cs
@@ -37,7 +37,7 @@ namespace Gtk {
 			IntPtr list_ptr = gtk_icon_theme_list_icons (Handle, native);
 			GLib.Marshaller.Free (native);
 			if (list_ptr == IntPtr.Zero)
-				return new string [0];
+				return Array.Empty<string> ();
 
 			GLib.List list = new GLib.List (list_ptr, typeof (string), true, true);
 			string[] result = new string [list.Count];
@@ -88,7 +88,7 @@ namespace Gtk {
 			set {
 				IntPtr[] native_path;
 				if (value == null)
-					native_path = new IntPtr [0];
+					native_path = Array.Empty<IntPtr> ();
 				else
 					native_path = GLib.Marshaller.StringArrayToNullTermPointer (value);
 

--- a/Source/Libs/GtkSharp/ImageMenuItem.cs
+++ b/Source/Libs/GtkSharp/ImageMenuItem.cs
@@ -18,6 +18,8 @@
 // Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 // Boston, MA 02111-1307, USA.
 
+using GLib;
+
 namespace Gtk {
 
 	using System;
@@ -32,7 +34,7 @@ namespace Gtk {
 		public ImageMenuItem (string label) : base (IntPtr.Zero)
 		{
 			if (GetType() != typeof (ImageMenuItem)) {
-				CreateNativeObject (new string [0], new GLib.Value [0]);
+				CreateNativeObject (Array.Empty<string> (), Array.Empty<Value> ());
 				AccelLabel al = new AccelLabel ("");
 				al.TextWithMnemonic = label;
 				al.SetAlignment (0.0f, 0.5f);

--- a/Source/Libs/GtkSharp/ListStore.cs
+++ b/Source/Libs/GtkSharp/ListStore.cs
@@ -18,6 +18,8 @@
 // Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 // Boston, MA 02111-1307, USA.
 
+using GLib;
+
 namespace Gtk {
 
 	using System;
@@ -172,7 +174,7 @@ namespace Gtk {
 
 		public ListStore (params GLib.GType[] types) : base (IntPtr.Zero)
 		{
-			CreateNativeObject (new string [0], new GLib.Value [0]);
+			CreateNativeObject (Array.Empty<string> (), Array.Empty<Value> ());
 			ColumnTypes = types;
 		}
 
@@ -185,7 +187,7 @@ namespace Gtk {
 				i++;
 			}
 			
-			CreateNativeObject (new string [0], new GLib.Value [0]);
+			CreateNativeObject (Array.Empty<string> (), Array.Empty<Value> ());
 			ColumnTypes = gtypes;
 		}
 

--- a/Source/Libs/GtkSharp/MenuItem.cs
+++ b/Source/Libs/GtkSharp/MenuItem.cs
@@ -18,6 +18,8 @@
 // Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 // Boston, MA 02111-1307, USA.
 
+using GLib;
+
 namespace Gtk {
 		
 	using System;
@@ -32,7 +34,7 @@ namespace Gtk {
 		public MenuItem (string label) : base (IntPtr.Zero)
 		{
 			if (GetType() != typeof (MenuItem)) {
-				CreateNativeObject (new string [0], new GLib.Value [0]);
+				CreateNativeObject (Array.Empty<string> (), Array.Empty<Value> ());
 				AccelLabel al = new AccelLabel ("");
 				al.TextWithMnemonic = label;
 				al.SetAlignment (0.0f, 0.5f);

--- a/Source/Libs/GtkSharp/Plug.cs
+++ b/Source/Libs/GtkSharp/Plug.cs
@@ -19,6 +19,8 @@
 // Boston, MA 02111-1307, USA.
 
 
+using GLib;
+
 namespace Gtk {
 
 	using System;
@@ -32,7 +34,7 @@ namespace Gtk {
 		public Plug (ulong socket_id) : base (IntPtr.Zero)
 		{
 			if (GetType () != typeof (Plug)) {
-				CreateNativeObject (new string [0], new GLib.Value [0]);
+				CreateNativeObject (Array.Empty<string> (), Array.Empty<Value> ());
 				Construct (Convert.ToUInt32(socket_id));
 				return;
 			}
@@ -45,7 +47,7 @@ namespace Gtk {
 		public Plug (Gdk.Display display, ulong socket_id) : base (IntPtr.Zero)
 		{
 			if (GetType () != typeof (Plug)) {
-				CreateNativeObject (new string [0], new GLib.Value [0]);
+				CreateNativeObject (Array.Empty<string> (), Array.Empty<Value> ());
 				ConstructForDisplay (display, Convert.ToUInt32(socket_id));
 				return;
 			}

--- a/Source/Libs/GtkSharp/RadioMenuItem.cs
+++ b/Source/Libs/GtkSharp/RadioMenuItem.cs
@@ -19,6 +19,8 @@
 // Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 // Boston, MA 02111-1307, USA.
 
+using GLib;
+
 namespace Gtk {
 
 	using System;
@@ -29,7 +31,7 @@ namespace Gtk {
 		public RadioMenuItem (string label) : base (IntPtr.Zero)
 		{
 			if (GetType() != typeof (RadioMenuItem)) {
-				CreateNativeObject (new string [0], new GLib.Value [0]);
+				CreateNativeObject (Array.Empty<string> (), Array.Empty<Value> ());
 				AccelLabel al = new AccelLabel ("");
 				al.TextWithMnemonic = label;
 				al.SetAlignment (0.0f, 0.5f);
@@ -49,7 +51,7 @@ namespace Gtk {
 		public RadioMenuItem (RadioMenuItem[] group, string label) : base (IntPtr.Zero)
 		{
 			if (GetType () != typeof (RadioMenuItem)) {
-				CreateNativeObject (new string [0], new GLib.Value [0]);
+				CreateNativeObject (Array.Empty<string> (), Array.Empty<Value> ());
 				AccelLabel al = new AccelLabel ("");
 				al.TextWithMnemonic = label;
 				al.SetAlignment (0.0f, 0.5f);

--- a/Source/Libs/GtkSharp/RadioToolButton.cs
+++ b/Source/Libs/GtkSharp/RadioToolButton.cs
@@ -18,6 +18,8 @@
 // Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 // Boston, MA 02111-1307, USA.
 
+using GLib;
+
 namespace Gtk {
 
 	using System;
@@ -31,7 +33,7 @@ namespace Gtk {
 		public RadioToolButton (RadioToolButton[] group) : base (IntPtr.Zero)
 		{
 			if (GetType () != typeof (RadioToolButton)) {
-				CreateNativeObject (new string [0], new GLib.Value [0]);
+				CreateNativeObject (Array.Empty<string> (), Array.Empty<Value> ());
 				Group = group;
 				return;
 			}

--- a/Source/Libs/GtkSharp/SelectionData.cs
+++ b/Source/Libs/GtkSharp/SelectionData.cs
@@ -18,6 +18,8 @@
 // Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 // Boston, MA 02111-1307, USA.
 
+using Gdk;
+
 namespace Gtk {
 
 	using System;
@@ -77,7 +79,7 @@ namespace Gtk {
 					GLib.Marshaller.Free (target_ptr);
 					return result;
 				} else
-					return new Gdk.Atom [0];
+					return Array.Empty<Atom> ();
 			}
 		}
 	}

--- a/Source/Libs/GtkSharp/Stock.cs
+++ b/Source/Libs/GtkSharp/Stock.cs
@@ -32,7 +32,7 @@ namespace Gtk {
 		{
 			IntPtr raw_ret = gtk_stock_list_ids ();
 			if (raw_ret == IntPtr.Zero)
-				return new string [0];
+				return Array.Empty<string> ();
 			GLib.SList list = new GLib.SList(raw_ret, typeof (string));
 			string[] result = new string [list.Count];
 			for (int i = 0; i < list.Count; i++)

--- a/Source/Libs/GtkSharp/TextBuffer.cs
+++ b/Source/Libs/GtkSharp/TextBuffer.cs
@@ -149,7 +149,7 @@ namespace Gtk {
 			UIntPtr length;
 			IntPtr raw_ret = gtk_text_buffer_serialize (Handle, content_buffer == null ? IntPtr.Zero : content_buffer.Handle, format == null ? IntPtr.Zero : format.Handle, ref start, ref end, out length);
 			if (raw_ret == IntPtr.Zero)
-				return new byte [0];
+				return Array.Empty<byte> ();
 			int sz = (int) (uint) length;
 			byte[] ret = new byte [sz];
 			Marshal.Copy (raw_ret, ret, 0, sz);

--- a/Source/Libs/GtkSharp/TextChildAnchor.cs
+++ b/Source/Libs/GtkSharp/TextChildAnchor.cs
@@ -32,7 +32,7 @@ namespace Gtk {
 			get {
 				IntPtr raw_ret = gtk_text_child_anchor_get_widgets (Handle);
 				if (raw_ret == IntPtr.Zero)
-					return new Widget [0];
+					return Array.Empty<Widget> ();
 				GLib.List list = new GLib.List(raw_ret);
 				Widget[] result = new Widget [list.Count];
 				for (int i = 0; i < list.Count; i++)

--- a/Source/Libs/GtkSharp/TextIter.cs
+++ b/Source/Libs/GtkSharp/TextIter.cs
@@ -41,7 +41,7 @@ namespace Gtk {
 			get {
 				IntPtr raw_ret = gtk_text_iter_get_marks (ref this);
 				if (raw_ret == IntPtr.Zero)
-					return new TextMark [0];
+					return Array.Empty<TextMark> ();
 				GLib.SList list = new GLib.SList(raw_ret);
 				TextMark[] result = new TextMark [list.Count];
 				for (int i = 0; i < list.Count; i++)
@@ -57,7 +57,7 @@ namespace Gtk {
 			get {
 				IntPtr raw_ret = gtk_text_iter_get_tags (ref this);
 				if (raw_ret == IntPtr.Zero)
-					return new TextTag [0];
+					return Array.Empty<TextTag> ();
 				GLib.SList list = new GLib.SList(raw_ret);
 				TextTag[] result = new TextTag [list.Count];
 				for (int i = 0; i < list.Count; i++)
@@ -73,7 +73,7 @@ namespace Gtk {
 		{
 			IntPtr raw_ret = gtk_text_iter_get_toggled_tags (ref this, toggled_on);
 			if (raw_ret == IntPtr.Zero)
-				return new TextTag [0];
+				return Array.Empty<TextTag> ();
 			GLib.SList list = new GLib.SList(raw_ret);
 			TextTag[] result = new TextTag [list.Count];
 			for (int i = 0; i < list.Count; i++)

--- a/Source/Libs/GtkSharp/TextMark.cs
+++ b/Source/Libs/GtkSharp/TextMark.cs
@@ -18,6 +18,8 @@
 // Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 // Boston, MA 02111-1307, USA.
 
+using GLib;
+
 namespace Gtk {
 
 	using System;
@@ -26,7 +28,7 @@ namespace Gtk {
 
 		protected TextMark () : base (IntPtr.Zero)
 		{
-			CreateNativeObject (new string [0], new GLib.Value [0]);
+			CreateNativeObject (Array.Empty<string> (), Array.Empty<Value> ());
 		}
 	}
 }

--- a/Source/Libs/GtkSharp/TextView.cs
+++ b/Source/Libs/GtkSharp/TextView.cs
@@ -19,6 +19,8 @@
 // Boston, MA 02111-1307, USA.
 
 
+using GLib;
+
 namespace Gtk {
 
 	using System;
@@ -33,7 +35,7 @@ namespace Gtk {
 		public TextView (TextBuffer buffer) : base (IntPtr.Zero)
 		{
 			if (GetType() != typeof (TextView)) {
-				CreateNativeObject (new string [0], new GLib.Value [0]);
+				CreateNativeObject (Array.Empty<string> (), Array.Empty<Value> ());
 				Buffer = buffer;
 				return;
 			}

--- a/Source/Libs/GtkSharp/TreeSelection.cs
+++ b/Source/Libs/GtkSharp/TreeSelection.cs
@@ -32,7 +32,7 @@ namespace Gtk {
 		{
 			IntPtr list_ptr = gtk_tree_selection_get_selected_rows2 (Handle, IntPtr.Zero);
 			if (list_ptr == IntPtr.Zero)
-				return new TreePath [0];
+				return Array.Empty<TreePath> ();
 
 			GLib.List list = new GLib.List (list_ptr, typeof (Gtk.TreePath));
 			return GLib.Marshaller.ListToArray<TreePath> (list);

--- a/Source/Libs/GtkSharp/TreeStore.cs
+++ b/Source/Libs/GtkSharp/TreeStore.cs
@@ -20,6 +20,8 @@
 // Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 // Boston, MA 02111-1307, USA.
 
+using GLib;
+
 namespace Gtk {
 
 	using System;
@@ -289,7 +291,7 @@ namespace Gtk {
 
 		public TreeStore (params GLib.GType[] types) : base (IntPtr.Zero)
 		{
-			CreateNativeObject (new string [0], new GLib.Value [0]);
+			CreateNativeObject (Array.Empty<string> (), Array.Empty<Value> ());
 			ColumnTypes = types;
 		}
 
@@ -302,7 +304,7 @@ namespace Gtk {
 				i++;
 			}
 			
-			CreateNativeObject (new string [0], new GLib.Value [0]);
+			CreateNativeObject (Array.Empty<string> (), Array.Empty<Value> ());
 			ColumnTypes = gtypes;
 		}
 

--- a/Source/Libs/GtkSharp/Widget.cs
+++ b/Source/Libs/GtkSharp/Widget.cs
@@ -23,6 +23,8 @@
 // Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 // Boston, MA 02111-1307, USA.
 
+using GLib;
+
 namespace Gtk {
 
 	using System;
@@ -133,7 +135,7 @@ namespace Gtk {
 				uint* raw_ptr = (uint*)(((long) gtype.GetClassPtr()) + (long) class_abi.GetFieldOffset("activate_signal"));
 
 				*raw_ptr = RegisterSignal ("activate_signal", gtype, GLib.Signal.Flags.RunLast, GLib.GType.None,
-						new GLib.GType [0], ActivateMarshalCallback);
+						Array.Empty<GType> (), ActivateMarshalCallback);
 			}
 		}
 
@@ -395,7 +397,7 @@ namespace Gtk {
 		{
 			IntPtr raw_ret = gtk_widget_list_mnemonic_labels (Handle);
 			if (raw_ret == IntPtr.Zero)
-				return new Widget [0];
+				return Array.Empty<Widget> ();
 			GLib.List list = new GLib.List(raw_ret);
 			Widget[] result = new Widget [list.Count];
 			for (int i = 0; i < list.Count; i++)

--- a/Source/Libs/GtkSharp/Window.cs
+++ b/Source/Libs/GtkSharp/Window.cs
@@ -19,6 +19,8 @@
 // Free Software Foundation, Inc., 59 Temple Place - Suite 330,
 // Boston, MA 02111-1307, USA.
 
+using Gdk;
+
 namespace Gtk {
 
 	using System;
@@ -41,7 +43,7 @@ namespace Gtk {
 			get {
 				IntPtr raw_ret = gtk_window_get_default_icon_list();
 				if (raw_ret == IntPtr.Zero)
-					return new Gdk.Pixbuf [0];
+					return Array.Empty<Pixbuf> ();
 				GLib.List list = new GLib.List(raw_ret);
 				Gdk.Pixbuf[] result = new Gdk.Pixbuf [list.Count];
 				for (int i = 0; i < list.Count; i++)
@@ -66,7 +68,7 @@ namespace Gtk {
 			get {
 				IntPtr raw_ret = gtk_window_get_icon_list(Handle);
 				if (raw_ret == IntPtr.Zero)
-					return new Gdk.Pixbuf [0];
+					return Array.Empty<Pixbuf> ();
 				GLib.List list = new GLib.List(raw_ret);
 				Gdk.Pixbuf[] result = new Gdk.Pixbuf [list.Count];
 				for (int i = 0; i < list.Count; i++)

--- a/Source/Libs/PangoSharp/AttrIterator.cs
+++ b/Source/Libs/PangoSharp/AttrIterator.cs
@@ -36,7 +36,7 @@ namespace Pango {
 			desc.Family = desc.Family; // change static string to allocated one
 			language = language_handle == IntPtr.Zero ? null : new Language (language_handle);
 			if (list_handle == IntPtr.Zero) {
-				extra_attrs = new Pango.Attribute [0];
+				extra_attrs = Array.Empty<Attribute> ();
 				return;
 			}
 			GLib.SList list = new GLib.SList (list_handle);
@@ -53,7 +53,7 @@ namespace Pango {
 			get {
 				IntPtr list_handle = pango_attr_iterator_get_attrs (Handle);
 				if (list_handle == IntPtr.Zero)
-					return new Pango.Attribute [0];
+					return Array.Empty<Attribute> ();
 				GLib.SList list = new GLib.SList (list_handle);
 				Pango.Attribute[] attrs = new Pango.Attribute [list.Count];
 				int i = 0;

--- a/Source/Libs/PangoSharp/Context.cs
+++ b/Source/Libs/PangoSharp/Context.cs
@@ -34,7 +34,7 @@ namespace Pango {
 				IntPtr array_ptr;
 				pango_context_list_families2 (Handle, out array_ptr, out count);
 				if (array_ptr == IntPtr.Zero)
-					return new FontFamily [0];
+					return Array.Empty<FontFamily> ();
 				FontFamily [] result = new FontFamily [count];
 				for (int i = 0; i < count; i++) {
 					IntPtr fam_ptr = Marshal.ReadIntPtr (array_ptr, i * IntPtr.Size);

--- a/Source/Libs/PangoSharp/FontFamily.cs
+++ b/Source/Libs/PangoSharp/FontFamily.cs
@@ -34,7 +34,7 @@ namespace Pango {
 				IntPtr array_ptr;
 				pango_font_family_list_faces2 (Handle, out array_ptr, out count);
 				if (array_ptr == IntPtr.Zero)
-					return new FontFace [0];
+					return Array.Empty<FontFace> ();
 				FontFace [] result = new FontFace [count];
 				for (int i = 0; i < count; i++) {
 					IntPtr fam_ptr = Marshal.ReadIntPtr (array_ptr, i * IntPtr.Size);

--- a/Source/Libs/PangoSharp/FontMap.cs
+++ b/Source/Libs/PangoSharp/FontMap.cs
@@ -34,7 +34,7 @@ namespace Pango {
 				IntPtr array_ptr;
 				pango_font_map_list_families2 (Handle, out array_ptr, out count);
 				if (array_ptr == IntPtr.Zero)
-					return new FontFamily [0];
+					return Array.Empty<FontFamily> ();
 				FontFamily [] result = new FontFamily [count];
 				for (int i = 0; i < count; i++) {
 					IntPtr fam_ptr = Marshal.ReadIntPtr (array_ptr, i * IntPtr.Size);

--- a/Source/Libs/PangoSharp/GlyphItem.cs
+++ b/Source/Libs/PangoSharp/GlyphItem.cs
@@ -34,7 +34,7 @@ namespace Pango {
 			IntPtr list_handle = pango_glyph_item_apply_attrs (ref this, native_text, list.Handle);
 			GLib.Marshaller.Free (native_text);
 			if (list_handle == IntPtr.Zero)
-				return new GlyphItem [0];
+				return Array.Empty<GlyphItem> ();
 			GLib.SList item_list = new GLib.SList (list_handle, typeof (GlyphItem));
 			GlyphItem[] result = new GlyphItem [item_list.Count];
 			int i = 0;

--- a/Source/Libs/PangoSharp/Layout.cs
+++ b/Source/Libs/PangoSharp/Layout.cs
@@ -33,7 +33,7 @@ namespace Pango {
 			get {
 				IntPtr list_ptr = pango_layout_get_lines(Handle);
 				if (list_ptr == IntPtr.Zero)
-					return new LayoutLine [0];
+					return Array.Empty<LayoutLine> ();
 				GLib.SList list = new GLib.SList(list_ptr, typeof (IntPtr));
 				LayoutLine[] result = new LayoutLine [list.Count];
 				for (int i = 0; i < list.Count; i++)
@@ -63,7 +63,7 @@ namespace Pango {
 				int count;
 				IntPtr array_ptr = pango_layout_get_log_attrs_readonly (Handle, out count);
 				if (array_ptr == IntPtr.Zero || count == 0)
-					return new LogAttr [0];
+					return Array.Empty<LogAttr> ();
 				LogAttr[] result = new LogAttr [count];
 				int[] array = new int [count];
 				Marshal.Copy(array_ptr, array, 0, count);

--- a/Source/Tools/GapiCodegen/Ctor.cs
+++ b/Source/Tools/GapiCodegen/Ctor.cs
@@ -119,10 +119,12 @@ namespace GtkSharp.Generation {
 
 				if (needs_chaining) {
 					sw.WriteLine ("\t\t\tif (GetType () != typeof (" + name + ")) {");
+					const string createNativeObjectEmpty = 
+						"\t\t\t\tCreateNativeObject (Array.Empty<string> (), Array.Empty<GLib.Value> ());\n" +
+					    "\t\t\t\treturn;";
 					
 					if (Parameters.Count == 0) {
-						sw.WriteLine ("\t\t\t\tCreateNativeObject (Array.Empty<string> (), Array.Empty<GLib.Value> ());");
-						sw.WriteLine ("\t\t\t\treturn;");
+						sw.WriteLine (createNativeObjectEmpty);
 					} else {
 						var names = new List<string> ();
 						var values = new List<string> ();
@@ -137,17 +139,19 @@ namespace GtkSharp.Generation {
 							}
 						}
 
-						//if (names.Count == Parameters.Count) {
+						if (names.Count != 0) {
+							//if (names.Count == Parameters.Count) {
 							sw.WriteLine ("\t\t\t\tvar vals = new List<GLib.Value> ();");
 							sw.WriteLine ("\t\t\t\tvar names = new List<string> ();");
 							for (int i = 0; i < names.Count; i++) {
-								Parameter p = Parameters [i];
+								Parameter p = Parameters[i];
 								string indent = "\t\t\t\t";
 								if (p.Generatable is ClassBase && !(p.Generatable is StructBase)) {
 									sw.WriteLine (indent + "if (" + p.Name + " != null) {");
 									indent += "\t";
 								}
-								sw.WriteLine (indent + "names.Add (\"" + names [i] + "\");");
+
+								sw.WriteLine (indent + "names.Add (\"" + names[i] + "\");");
 								sw.WriteLine (indent + "vals.Add (new GLib.Value (" + values[i] + "));");
 
 								if (p.Generatable is ClassBase && !(p.Generatable is StructBase))
@@ -156,8 +160,11 @@ namespace GtkSharp.Generation {
 
 							sw.WriteLine ("\t\t\t\tCreateNativeObject (names.ToArray (), vals.ToArray ());");
 							sw.WriteLine ("\t\t\t\treturn;");
-						//} else
-						//	sw.WriteLine ("\t\t\t\tthrow new InvalidOperationException (\"Can't override this constructor.\");");
+							//} else
+							//	sw.WriteLine ("\t\t\t\tthrow new InvalidOperationException (\"Can't override this constructor.\");");
+						} else {
+							sw.WriteLine (createNativeObjectEmpty);
+						}
 					}
 					
 					sw.WriteLine ("\t\t\t}");


### PR DESCRIPTION
replaced new[0] with array empty in non-generated code

in GapiCodegen/Ctor.cs:
if no fitting parameters found, use Array.Empty

Examples:

Before:

```
			if (GetType () != typeof (NoOpObject)) {
				var vals = new List<GLib.Value> ();
				var names = new List<string> ();
				CreateNativeObject (names.ToArray (), vals.ToArray ());
				return;
			}
```
After:

```
			if (GetType () != typeof (NoOpObject)) {
				CreateNativeObject (Array.Empty<string> (), Array.Empty<GLib.Value> ());
				return;
			}
```

if no nullable parameters found, use Array Initializer instead of list

Examples:

Before:

```
			if (GetType () != typeof (SimplePermission)) {
				var vals = new List<GLib.Value> ();
				var names = new List<string> ();
				names.Add ("allowed");
				vals.Add (new GLib.Value (allowed));
				CreateNativeObject (names.ToArray (), vals.ToArray ());
				return;
			}
```

after:

```
			if (GetType () != typeof (SimplePermission)) {
				CreateNativeObject (
				new[] {"allowed"},
				new[] {new GLib.Value (allowed)}
				);
				return;
			}
```