### PR TITLE
GLibSharp.csproj: add extension for missing g_signal_connect_data

### DIFF
--- a/Source/Libs/GLibSharp/SignalClosure.cs
+++ b/Source/Libs/GLibSharp/SignalClosure.cs
@@ -183,7 +183,7 @@ namespace GLib {
 		}
 
 		[UnmanagedFunctionPointer (CallingConvention.Cdecl)]
-		delegate void ClosureNotify (IntPtr data, IntPtr closure);
+		internal delegate void ClosureNotify (IntPtr data, IntPtr closure);
 
 		static void NotifyCallback (IntPtr data, IntPtr raw_closure)
 		{

--- a/Source/Libs/GLibSharp/SignalExtensions.cs
+++ b/Source/Libs/GLibSharp/SignalExtensions.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace GLib
+{
+
+	public static class SignalExtensions
+	{
+
+		// missing in GtkSharp; also not found in *-api.xml's
+		// https://docs.gtk.org/gobject/func.signal_connect_data.html
+		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+		delegate ulong d_g_signal_connect_data(IntPtr instance, string detailed_signal, IntPtr c_handler, IntPtr data, SignalClosure.ClosureNotify destroy_data, ConnectFlags connect_flags);
+
+		static d_g_signal_connect_data g_signal_connect_data = FuncLoader.LoadFunction<d_g_signal_connect_data>(FuncLoader.GetProcAddress(GLibrary.Load(Library.Gio), "g_signal_connect_data"));
+
+		public static ulong SignalConnectData<TDelegate>(this GLib.Object instance, string detailed_signal, TDelegate callBack, IntPtr data = default, ConnectFlags connect_flags = 0) where TDelegate : Delegate
+		{
+			var c_handler = Marshal.GetFunctionPointerForDelegate(callBack);
+
+			return g_signal_connect_data(instance.Handle, detailed_signal, c_handler, data, null, connect_flags);
+		}
+
+	}
+
+}


### PR DESCRIPTION
this is a workaround

i guess it should be handled somehow with signal, but i don't get through the signal handling

any ideas? @zii-dmg @thiblahute @harry-cpp 