### PR TITLE
added VSCode launch.json configuration for cake script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -315,3 +315,6 @@ OpenCover/
 
 # macOS metadata
 .DS_Store
+
+# created by CSDevKit
+.mono/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,11 +1,8 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {
-            "name": ".NET Core Launch (console)",
+            "name": "Samples",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
@@ -16,36 +13,20 @@
             "stopAtEntry": false,
             "internalConsoleOptions": "openOnSessionStart"
         },
-        {
-            "name": ".NET Core Launch (web)",
+        {   // install VSCode Cake extension for source-level debugging of the cake script
+            "name": "Cake Build Script (InstallWorkload)",
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "build",
-            "program": "${workspaceFolder}/bin/Debug/<insert-target-framework-here>/<insert-project-name-here>.dll",
-            "args": [],
-            "cwd": "${workspaceFolder}",
+            "program": "${env:HOME}/.nuget/packages/cake.tool/2.0.0/tools/net6.0/any/Cake.dll",
+            "args": [
+                "${workspaceRoot}/build.cake",
+                "--BuildTarget=InstallWorkload",
+                "--debug",
+                "--verbosity=diagnostic"
+            ],
+            "cwd": "${workspaceRoot}",
             "stopAtEntry": false,
-            "internalConsoleOptions": "openOnSessionStart",
-            "launchBrowser": {
-                "enabled": true,
-                "args": "${auto-detect-url}",
-                "windows": {
-                    "command": "cmd.exe",
-                    "args": "/C start ${auto-detect-url}"
-                },
-                "osx": {
-                    "command": "open"
-                },
-                "linux": {
-                    "command": "xdg-open"
-                }
-            },
-            "env": {
-                "ASPNETCORE_ENVIRONMENT": "Development"
-            },
-            "sourceFileMap": {
-                "/Views": "${workspaceFolder}/Views"
-            }
+            "externalConsole": false
         },
         {
             "name": ".NET Core Attach",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,7 @@
     "tasks": [
         {
             "label": "build",
-            "command": "dotnet build Source/Samples/Samples.csproj",
+            "command": "dotnet build ${workspaceRoot}/Source/Samples/Samples.csproj",
             "type": "shell",
             "group": "build",
             "presentation": {

--- a/CakeScripts/TargetEnvironment.cake
+++ b/CakeScripts/TargetEnvironment.cake
@@ -33,7 +33,26 @@ class TargetEnvironment
             }
             else if (OperatingSystem.IsLinux())
             {
-                DotNetInstallPath = "/usr/share/dotnet";
+                var userHomeDirectory = Environment.GetEnvironmentVariable("HOME");
+                if (userHomeDirectory != null)
+                {
+                    if (userHomeDirectory != "/root")
+                        DotNetInstallPath = P.Combine(userHomeDirectory, ".dotnet");  // default to user home directory
+                    if (!D.Exists(DotNetInstallPath))
+                        DotNetInstallPath = null;  // SDK not found in user home directory
+
+                    if (DotNetInstallPath == null)
+                    {
+                        DotNetInstallPath = "/usr/share/dotnet";  // assume Ubuntu 22.04 when installed from packages.microsoft.com
+                        if (!D.Exists(DotNetInstallPath))
+                            DotNetInstallPath = "/usr/share/dotnet";  // else try Ubuntu Jammy feed
+                        if (!D.Exists(DotNetInstallPath))
+                            DotNetInstallPath = null;  // SDK not found in both paths
+                    }
+                }
+                
+                if (DotNetInstallPath != null)
+                    Console.WriteLine($"DOTNET_ROOT environment variable wasn't set, using SDK in {DotNetInstallPath}. Setting DOTNET_ROOT is highly recommended.");
             }
             else if (OperatingSystem.IsMacOS())
             {

--- a/build.cake
+++ b/build.cake
@@ -14,7 +14,7 @@ var configuration = Argument("Configuration", "Release");
 
 var msbuildsettings = new DotNetMSBuildSettings();
 var list = new List<GAssembly>();
-var supportedVersionBands = new List<string>() {"6.0.100", "6.0.200", "6.0.300", "6.0.400", "7.0.400", "8.0.100", "8.0.200"};
+var supportedVersionBands = new List<string>() {"6.0.100", "6.0.200", "6.0.300", "6.0.400", "7.0.400", "8.0.100", "8.0.200", "8.0.300", "8.0.400"};
 
 // TASKS
 


### PR DESCRIPTION
I cleaned up the .vscode folder a bit:

- removed the unnecessary launcher for the web app
- added a cake build launcher for source-level debugging of the cake scripts (requires the Cake extension for VSCode)

![grafik](https://github.com/GtkSharp/GtkSharp/assets/11477743/3b1411fb-3e2c-430f-aa56-3b5fdf31315b)

This has been testen on Windows 11 and a Debian Bookworm WSL.