### PR TITLE
Fix `libgtk-3.0.dylib` not found even when MacPorts `gtk3` is installed

### DIFF
--- a/CakeScripts/TargetEnvironment.cake
+++ b/CakeScripts/TargetEnvironment.cake
@@ -36,7 +36,16 @@ class TargetEnvironment
             }
             else if (OperatingSystem.IsMacOS())
             {
-                DotNetInstallPath = "/usr/local/share/dotnet";
+                string[] PotentialPath = {"/usr/local/share/dotnet", "/opt/local/share/dotnet", "/opt/homebrew/share/dotnet"};
+
+                foreach ( var Path in PotentialPath )
+                {
+                    if (D.Exists(Path))
+                    {
+                        DotNetInstallPath = Path;
+                        break;
+                    }
+                }
             }
         }
 

--- a/Source/Libs/Shared/GLibrary.cs
+++ b/Source/Libs/Shared/GLibrary.cs
@@ -69,13 +69,13 @@ class GLibrary
 				ret = FuncLoader.LoadLibrary(_libraryDefinitions[library][0]);
 			}
 		} else if (FuncLoader.IsOSX) {
-			ret = FuncLoader.LoadLibrary(_libraryDefinitions[library][2]);
+			string[] libPath = {"", "/usr/local/lib/", "/opt/local/lib/", "/opt/homebrew/lib/"};
 
-			if (ret == IntPtr.Zero) {
-				ret = FuncLoader.LoadLibrary("/usr/local/lib/" + _libraryDefinitions[library][2]);
-				if (ret == IntPtr.Zero) {
-					ret = FuncLoader.LoadLibrary("/opt/homebrew/lib/" + _libraryDefinitions[library][2]);
-				}
+			foreach ( string path in libPath ) {
+				ret = FuncLoader.LoadLibrary(path + _libraryDefinitions[library][2]);
+
+				if (ret != IntPtr.Zero)
+					break;
 			}
 		} else
 			ret = FuncLoader.LoadLibrary(_libraryDefinitions[library][1]);


### PR DESCRIPTION
Fix `libgtk-3.0.dylib` not found even when MacPorts `gtk3` is installed.
```sh
Unhandled exception. System.TypeInitializationException: The type initializer for 'Gtk.Application' threw an exception.
 ---> System.DllNotFoundException: Gtk: libgtk-3-0.dll, libgtk-3.so.0, libgtk-3.0.dylib, gtk-3.dll
   at GLibrary.Load(Library library)
   at Gtk.Application..cctor()
   --- End of inner exception stack trace ---
   at Gtk.Application.Init()
   at gtkSharp.Program.Main(String[] args)
```
It solves my problem of having to use MacPorts instead of Brew :) due to compatibility.
Improve #1 MacOS support.
Most likely fixes issues #78 and #249.