### PR TITLE
Fixed native-sized int marshalling

### DIFF
--- a/Source/Libs/GLibSharp/FileUtils.cs
+++ b/Source/Libs/GLibSharp/FileUtils.cs
@@ -27,15 +27,15 @@ namespace GLib {
 	public class FileUtils
 	{
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-		delegate bool d_g_file_get_contents(IntPtr filename, out IntPtr contents, out int length, out IntPtr error);
+		delegate bool d_g_file_get_contents(IntPtr filename, out IntPtr contents, out UIntPtr length, out IntPtr error);
 		static d_g_file_get_contents g_file_get_contents = FuncLoader.LoadFunction<d_g_file_get_contents>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GLib), "g_file_get_contents"));
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-		delegate bool d_g_file_get_contents_utf8(IntPtr filename, out IntPtr contents, out int length, out IntPtr error);
-		static d_g_file_get_contents_utf8 g_file_get_contents_utf8 = FuncLoader.LoadFunction<d_g_file_get_contents_utf8>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GObject), "g_file_get_contents_utf8"));
+		delegate bool d_g_file_get_contents_utf8(IntPtr filename, out IntPtr contents, out UIntPtr length, out IntPtr error);
+		static d_g_file_get_contents_utf8 g_file_get_contents_utf8 = FuncLoader.LoadFunction<d_g_file_get_contents_utf8>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GLib), "g_file_get_contents_utf8"));
 
 		public static string GetFileContents (string filename)
 		{
-			int length;
+			UIntPtr length;
 			IntPtr contents, error;
 			IntPtr native_filename = Marshaller.StringToPtrGStrdup (filename);
 
@@ -48,7 +48,7 @@ namespace GLib {
 			}
 
 			Marshaller.Free (native_filename);
-			return Marshaller.Utf8PtrToString (contents);
+			return Marshaller.PtrToStringGFree (contents);
 		}
 
 		private FileUtils () {}

--- a/Source/Libs/GLibSharp/Markup.cs
+++ b/Source/Libs/GLibSharp/Markup.cs
@@ -30,7 +30,7 @@ namespace GLib {
 		private Markup () {}
 		
 		[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-		delegate IntPtr d_g_markup_escape_text(IntPtr text, int len);
+		delegate IntPtr d_g_markup_escape_text(IntPtr text, IntPtr length);
 		static d_g_markup_escape_text g_markup_escape_text = FuncLoader.LoadFunction<d_g_markup_escape_text>(FuncLoader.GetProcAddress(GLibrary.Load(Library.GLib), "g_markup_escape_text"));
 		
 		static public string EscapeText (string s)
@@ -39,7 +39,7 @@ namespace GLib {
 				return String.Empty;
 
 			IntPtr native = Marshaller.StringToPtrGStrdup (s);
-			string result = Marshaller.PtrToStringGFree (g_markup_escape_text (native, -1));
+			string result = Marshaller.PtrToStringGFree (g_markup_escape_text (native, (IntPtr)(-1)));
 			Marshaller.Free (native);
 			return result;
 		}


### PR DESCRIPTION
https://docs.gtk.org/glib/types.html#gsize:
> gsize is usually 32 bit wide on a 32-bit platform and 64 bit wide on a 64-bit platform.

**g_markup_escape_text:**
```c
gchar*
g_markup_escape_text (
  const gchar* text,
  gssize length
)
```
* gssize length: int -> IntPtr

**g_file_get_contents(_utf8):**
```c
gboolean
g_file_get_contents (
  const gchar* filename,
  gchar** contents,
  gsize* length,
  GError** error
)
```
* gsize length: int -> UIntPtr
* lib GObject -> GLib
* free memory of contents